### PR TITLE
Add new function material

### DIFF
--- a/include/materials/GraphiteTwoGrpXSFunctionMaterial.h
+++ b/include/materials/GraphiteTwoGrpXSFunctionMaterial.h
@@ -1,0 +1,50 @@
+#ifndef GRAPHITETWOGRPXSFUNCTIONMATERIAL_H_
+#define GRAPHITETWOGRPXSFUNCTIONMATERIAL_H_
+
+#include "GenericConstantMaterial.h"
+#include "SplineInterpolation.h"
+#include "BicubicSplineInterpolation.h"
+#include "MonotoneCubicInterpolation.h"
+#include "LinearInterpolation.h"
+
+class GraphiteTwoGrpXSFunctionMaterial;
+
+template <>
+InputParameters validParams<GraphiteTwoGrpXSFunctionMaterial>();
+
+class GraphiteTwoGrpXSFunctionMaterial : public GenericConstantMaterial
+{
+public:
+  GraphiteTwoGrpXSFunctionMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  const VariableValue & _T;
+  // const MaterialProperty<Real> & _rho;
+
+  MaterialProperty<std::vector<Real>> & _remxs;
+  MaterialProperty<std::vector<Real>> & _fissxs;
+  MaterialProperty<std::vector<Real>> & _nsf;
+  MaterialProperty<std::vector<Real>> & _fisse;
+  MaterialProperty<std::vector<Real>> & _diffcoef;
+  MaterialProperty<std::vector<Real>> & _recipvel;
+  MaterialProperty<std::vector<Real>> & _chi;
+  MaterialProperty<std::vector<Real>> & _gtransfxs;
+  MaterialProperty<std::vector<Real>> & _beta_eff;
+  MaterialProperty<Real> & _beta;
+  MaterialProperty<std::vector<Real>> & _decay_constant;
+  MaterialProperty<std::vector<Real>> & _d_remxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_fissxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_nsf_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_fisse_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_diffcoef_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_recipvel_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_chi_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_gtransfxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_beta_eff_d_temp;
+  MaterialProperty<Real> & _d_beta_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_decay_constant_d_temp;
+};
+
+#endif // GRAPHITETWOGRPXSFUNCTIONMATERIAL_H

--- a/include/materials/MsreFuelTwoGrpXSFunctionMaterial.h
+++ b/include/materials/MsreFuelTwoGrpXSFunctionMaterial.h
@@ -1,0 +1,50 @@
+#ifndef MSREFUELTWOGRPXSFUNCTIONMATERIAL_H_
+#define MSREFUELTWOGRPXSFUNCTIONMATERIAL_H_
+
+#include "GenericConstantMaterial.h"
+#include "SplineInterpolation.h"
+#include "BicubicSplineInterpolation.h"
+#include "MonotoneCubicInterpolation.h"
+#include "LinearInterpolation.h"
+
+class MsreFuelTwoGrpXSFunctionMaterial;
+
+template <>
+InputParameters validParams<MsreFuelTwoGrpXSFunctionMaterial>();
+
+class MsreFuelTwoGrpXSFunctionMaterial : public GenericConstantMaterial
+{
+public:
+  MsreFuelTwoGrpXSFunctionMaterial(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpProperties();
+
+  const VariableValue & _T;
+  // const MaterialProperty<Real> & _rho;
+
+  MaterialProperty<std::vector<Real>> & _remxs;
+  MaterialProperty<std::vector<Real>> & _fissxs;
+  MaterialProperty<std::vector<Real>> & _nsf;
+  MaterialProperty<std::vector<Real>> & _fisse;
+  MaterialProperty<std::vector<Real>> & _diffcoef;
+  MaterialProperty<std::vector<Real>> & _recipvel;
+  MaterialProperty<std::vector<Real>> & _chi;
+  MaterialProperty<std::vector<Real>> & _gtransfxs;
+  MaterialProperty<std::vector<Real>> & _beta_eff;
+  MaterialProperty<Real> & _beta;
+  MaterialProperty<std::vector<Real>> & _decay_constant;
+  MaterialProperty<std::vector<Real>> & _d_remxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_fissxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_nsf_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_fisse_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_diffcoef_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_recipvel_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_chi_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_gtransfxs_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_beta_eff_d_temp;
+  MaterialProperty<Real> & _d_beta_d_temp;
+  MaterialProperty<std::vector<Real>> & _d_decay_constant_d_temp;
+};
+
+#endif // MSREFUELTWOGRPXSFUNCTIONMATERIAL_H

--- a/problems/MooseGold/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections_eigen.i
+++ b/problems/MooseGold/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections_eigen.i
@@ -1,63 +1,54 @@
-# This input file tests outflow boundary conditions for the incompressible NS equations.
-width = 3.048
-height = 1.016
-length = 162.56
+flow_velocity=21.7 # cm/s. See MSRE-properties.ods
 nt_scale=1e13
+ini_temp=922
+diri_temp=922
 
 [GlobalParams]
   num_groups = 2
   num_precursor_groups = 6
   use_exp_form = false
   group_fluxes = 'group1 group2'
-  sss2_input = false
-  account_delayed = false
   temperature = 922
+  sss2_input = false
   pre_concs = 'pre1 pre2 pre3 pre4 pre5 pre6'
-  gamma = .0144 # Cammi .0144
-  nt_scale = ${nt_scale}
+  account_delayed = false
 []
 
 [Mesh]
-  file = single_channel_msre_dimensions.msh
+  file = '2d_lattice_structured.msh'
+  # file = '2d_lattice_structured_jac.msh'
+[../]
+
+[MeshModifiers]
+  [./scale]
+    type = Transform
+    transform = SCALE
+    vector_value = '.369 .369 1'
+  [../]
 []
 
+
+[Problem]
+  coord_type = RZ
+[]
 
 [Variables]
   [./group1]
     order = FIRST
     family = LAGRANGE
-    # initial_condition = 1
+    initial_condition = 1
     # scaling = 1e4
   [../]
   [./group2]
     order = FIRST
     family = LAGRANGE
-    # initial_condition = 1
+    initial_condition = 1
     # scaling = 1e4
   [../]
 []
 
-# [PrecursorKernel]
-#   var_name_base = pre
-#   block = 'fuel'
-#   outlet_boundaries = 'fuel_top'
-#   u_func = vel_x_func
-#   v_func = vel_y_func
-#   w_func = vel_z_func
-#   constant_velocity_values = false
-#   nt_exp_form = false
-#   family = MONOMIAL
-#   order = CONSTANT
-#   # jac_test = true
-# []
-
 [Kernels]
   # Neutronics
-  # [./time_group1]
-  #   type = NtTimeDerivative
-  #   variable = group1
-  #   group_number = 1
-  # [../]
   [./diff_group1]
     type = GroupDiffusion
     variable = group1
@@ -73,10 +64,6 @@ nt_scale=1e13
     variable = group1
     group_number = 1
   [../]
-  # [./delayed_group1]
-  #   type = DelayedNeutronSource
-  #   variable = group1
-  # [../]
   [./inscatter_group1]
     type = InScatter
     variable = group1
@@ -102,56 +89,42 @@ nt_scale=1e13
     variable = group2
     group_number = 2
   [../]
-  # [./time_group2]
-  #   type = NtTimeDerivative
-  #   variable = group2
-  #   group_number = 2
-  # [../]
 []
 
 [BCs]
   [./vacuum_group1]
     type = VacuumConcBC
-    boundary = 'fuel_bottom fuel_top moderator_bottoms moderator_tops'
-    # boundary = 'fuel_bottom moderator_bottoms'
+    boundary = 'fuel_bottoms fuel_tops moder_bottoms moder_tops outer_wall'
     variable = group1
   [../]
   [./vacuum_group2]
     type = VacuumConcBC
-    boundary = 'fuel_bottom fuel_top moderator_bottoms moderator_tops'
-    # boundary = 'fuel_bottom moderator_bottoms'
+    boundary = 'fuel_bottoms fuel_tops moder_bottoms moder_tops outer_wall'
     variable = group2
   [../]
 []
 
 [Materials]
   [./fuel]
-    type = GenericMoltresMaterial
-    property_tables_root = '../property_file_dir/newt_msre_fuel_'
-    interp_type = 'spline'
+    type = MsreFuelTwoGrpXSFunctionMaterial
     block = 'fuel'
-    prop_names = 'k cp rho'
-    prop_values = '.0553 1967 2.146e-3' # Robertson MSRE technical report @ 922 K
   [../]
   [./moder]
-    type = GenericMoltresMaterial
-    property_tables_root = '../property_file_dir/newt_msre_mod_'
-    interp_type = 'spline'
-    prop_names = 'k cp rho'
-    prop_values = '.312 1760 1.86e-3' # Cammi 2011 at 908 K
-    block = 'moderator'
+    type = GraphiteTwoGrpXSFunctionMaterial
+    block = 'moder'
   [../]
-[]
-
-[Debug]
-  show_var_residual_norms = true
-[]
-
-[Preconditioning]
-  [./SMP_PJFNK]
-    type = SMP
-    full = true
-  [../]
+  # [./fuel]
+  #   type = GenericMoltresMaterial
+  #   property_tables_root = '../property_file_dir/newt_msre_fuel_'
+  #   interp_type = 'spline'
+  #   block = 'fuel'
+  # [../]
+  # [./moder]
+  #   type = GenericMoltresMaterial
+  #   property_tables_root = '../property_file_dir/newt_msre_mod_'
+  #   interp_type = 'spline'
+  #   block = 'moder'
+  # [../]
 []
 
 [Executioner]
@@ -160,41 +133,21 @@ nt_scale=1e13
   xdiff = 'group1diff'
 
   bx_norm = 'bnorm'
-  k0 = 2.0
+  k0 = 1.5
   pfactor = 1e-2
   l_max_its = 100
 
   # solve_type = 'PJFNK'
   solve_type = 'NEWTON'
   petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_linesearch_monitor'
-  petsc_options_iname = '-pc_type'
-  petsc_options_value = 'lu'
+  petsc_options_iname = '-pc_type -sub_pc_type'
+  petsc_options_value = 'asm lu'
 []
 
-[Outputs]
-  print_perf_log = true
-  exodus = true
-  csv = true
-  file_base = 'out'
-[]
-
-[Functions]
-  [./nt_ic]
-    type = ParsedFunction
-    value = '10 * sin(pi * z / ${length})'
-  [../]
-[]
-
-[ICs]
-  [./group1]
-    type = FunctionIC
-    variable = group1
-    function = nt_ic
-  [../]
-  [./group2]
-    type = FunctionIC
-    variable = group2
-    function = nt_ic
+[Preconditioning]
+  [./SMP]
+    type = SMP
+    full = true
   [../]
 []
 
@@ -240,3 +193,37 @@ nt_scale=1e13
     use_displaced_mesh = false
   [../]
 []
+
+[Outputs]
+  print_perf_log = true
+  print_linear_residuals = true
+  [./exodus]
+    type = Exodus
+    execute_on = 'timestep_end final'
+  [../]
+[]
+
+[Debug]
+  show_var_residual_norms = true
+[]
+
+# [ICs]
+#   [./temp_ic]
+#     type = RandomIC
+#     variable = temp
+#     min = 922
+#     max = 1022
+#   [../]
+#   [./group1_ic]
+#     type = RandomIC
+#     variable = group1
+#     min = .5
+#     max = 1.5
+#   [../]
+#   [./group2_ic]
+#     type = RandomIC
+#     variable = group2
+#     min = .5
+#     max = 1.5
+#   [../]
+# []

--- a/problems/MooseGold/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
+++ b/problems/MooseGold/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
@@ -19,6 +19,14 @@ diri_temp=922
   # file = jac_test.msh
 []
 
+[MeshModifiers]
+  [./scale]
+    type = Transform
+    transform = SCALE
+    vector_value = '1 1 .5'
+  [../]
+[]
+
 [Problem]
 []
 

--- a/problems/MooseGold/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
+++ b/problems/MooseGold/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
@@ -310,9 +310,18 @@ diri_temp=922
   [../]
   [./average_fission_heat]
     type = AverageFissionHeat
-    execute_on = 'linear nonlinear'
+    execute_on = 'timestep_end'
+    # execute_on = 'linear nonlinear timestep_end'
     outputs = 'csv console'
     block = 'fuel'
+  [../]
+  [./peak_power_density]
+    type = ElementExtremeValue
+    value_type = max
+    variable = power_density
+    execute_on = 'timestep_end'
+    # execute_on = 'linear nonlinear timestep_end'
+    outputs = 'csv console'
   [../]
 []
 
@@ -320,8 +329,8 @@ diri_temp=922
   print_perf_log = true
   print_linear_residuals = true
   csv = true
-  # exodus = true
-  nemesis = true
+  exodus = true
+  # nemesis = true
 []
 
 [Debug]

--- a/problems/MooseGold/single_msre_channel_velocity_heat_nts/diffusion_solution_aux.i
+++ b/problems/MooseGold/single_msre_channel_velocity_heat_nts/diffusion_solution_aux.i
@@ -1,0 +1,91 @@
+[Mesh]
+  type = GeneratedMesh
+  nx = 20
+  ny = 20
+  dim = 2
+  xmin = -0.5
+  ymin = -0.5
+  xmax = 0.5
+  ymax = .5
+[]
+
+[MeshModifiers]
+  [./box]
+    type = SubdomainBoundingBox
+    # bottom_left = '0 -.25 0'
+    # top_right = '.5 .25 0'
+    bottom_left = '-.25 -.25 0'
+    top_right = '.25 .25 0'
+    block_id = 1
+    block_name = box
+  [../]
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+    initial_condition = 0.0
+  [../]
+[]
+
+[AuxVariables]
+  [./v]
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+[]
+
+[AuxKernels]
+  [./v]
+    type = SolutionAux
+    solution = soln
+    variable = v
+    from_variable = u
+    block = box
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    boundary = left
+    variable = u
+    value = 1
+  [../]
+  [./right]
+    type = DirichletBC
+    boundary = right
+    variable = u
+    value = 0
+  [../]
+[]
+
+[UserObjects]
+  [./soln]
+    type = SolutionUserObject
+    mesh = solution_out.e
+    system_variables = 'u'
+    timestep = LATEST
+    rotation0_vector = '0 0 1'
+    rotation0_angle = 90
+    # translation = '.25 0 0'
+    # transformation_order = 'rotation0 translation'
+    transformation_order = 'rotation0'
+    # transformation_order = 'translation'
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+[]
+
+[Outputs]
+  exodus = true
+  execute_on = 'timestep_end'
+[]

--- a/problems/MooseGold/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
+++ b/problems/MooseGold/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
@@ -1,0 +1,416 @@
+# This input file tests outflow boundary conditions for the incompressible NS equations.
+width = 3.048
+height = 1.016
+length = 162.56
+nt_scale=1e13
+
+[GlobalParams]
+  num_groups = 2
+  num_precursor_groups = 6
+  use_exp_form = false
+  group_fluxes = 'group1 group2'
+  sss2_input = false
+  account_delayed = false
+  temperature = temp
+  pre_concs = 'pre1 pre2 pre3 pre4 pre5 pre6'
+  gamma = .0144 # Cammi .0144
+  nt_scale = ${nt_scale}
+[]
+
+[Mesh]
+  file = msre_squares.msh
+[]
+
+
+[Variables]
+  [./group1]
+    order = FIRST
+    family = LAGRANGE
+    # initial_condition = 1
+    scaling = 1e2
+  [../]
+  [./group2]
+    order = FIRST
+    family = LAGRANGE
+    # initial_condition = 1
+    scaling = 1e2
+  [../]
+  [./temp]
+    order = FIRST
+    family = LAGRANGE
+    scaling = 1e-4
+    # initial_condition = 900
+  [../]
+[]
+
+[AuxVariables]
+  # [./vel_x]
+  #   block = 'fuel'
+  # [../]
+  # [./vel_y]
+  #   block = 'fuel'
+  # [../]
+  # [./vel_z]
+  #   block = 'fuel'
+  # [../]
+  # [./p]
+  #   block = 'fuel'
+  # [../]
+  [./power_density]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+# [PrecursorKernel]
+#   var_name_base = pre
+#   block = 'fuel'
+#   outlet_boundaries = 'fuel_top'
+#   u_func = vel_x_func
+#   v_func = vel_y_func
+#   w_func = vel_z_func
+#   constant_velocity_values = false
+#   nt_exp_form = false
+#   family = MONOMIAL
+#   order = CONSTANT
+#   # jac_test = true
+# []
+
+[Kernels]
+  # Neutronics
+  [./time_group1]
+    type = NtTimeDerivative
+    variable = group1
+    group_number = 1
+  [../]
+  [./diff_group1]
+    type = GroupDiffusion
+    variable = group1
+    group_number = 1
+  [../]
+  [./sigma_r_group1]
+    type = SigmaR
+    variable = group1
+    group_number = 1
+  [../]
+  [./fission_source_group1]
+    type = CoupledFissionKernel
+    variable = group1
+    group_number = 1
+  [../]
+  # [./delayed_group1]
+  #   type = DelayedNeutronSource
+  #   variable = group1
+  # [../]
+  [./inscatter_group1]
+    type = InScatter
+    variable = group1
+    group_number = 1
+  [../]
+  [./diff_group2]
+    type = GroupDiffusion
+    variable = group2
+    group_number = 2
+  [../]
+  [./sigma_r_group2]
+    type = SigmaR
+    variable = group2
+    group_number = 2
+  [../]
+  [./fission_source_group2]
+    type = CoupledFissionKernel
+    variable = group2
+    group_number = 2
+  [../]
+  [./inscatter_group2]
+    type = InScatter
+    variable = group2
+    group_number = 2
+  [../]
+  [./time_group2]
+    type = NtTimeDerivative
+    variable = group2
+    group_number = 2
+  [../]
+
+  [./temp_time_derivative]
+    type = MatINSTemperatureTimeDerivative
+    variable = temp
+  [../]
+  # [./temp_fuel_transport]
+  #   type = INSTemperature
+  #   u = vel_x
+  #   v = vel_y
+  #   w = vel_z
+  #   variable = temp
+  #   block = 'fuel'
+  # [../]
+  [./temp_advection_fuel]
+    type = ConservativeTemperatureAdvection
+    velocity = '0 0 21.73'
+    variable = temp
+    block = 'fuel'
+  [../]
+  [./temp_mod_transport]
+    type = MatDiffusion
+    D_name = 'k'
+    variable = temp
+    # block = 'moderator'
+  [../]
+  [./temp_source_fuel]
+    type = TransientFissionHeatSource
+    variable = temp
+    block = 'fuel'
+  [../]
+  [./temp_source_mod]
+    type = GammaHeatSource
+    variable = temp
+    block = 'moderator'
+    average_fission_heat = 'average_fission_heat'
+  [../]
+[]
+
+[AuxKernels]
+  [./fuel]
+    block = 'fuel'
+    type = FissionHeatSourceTransientAux
+    variable = power_density
+  [../]
+  [./moderator]
+    block = 'moderator'
+    type = ModeratorHeatSourceTransientAux
+    average_fission_heat = 'average_fission_heat'
+    variable = power_density
+  [../]
+[]
+
+[BCs]
+  [./temp_inlet]
+    boundary = 'fuel_bottoms'
+    variable = temp
+    value = 900
+    type = DirichletBC
+  [../]
+  [./temp_advection_outlet]
+    boundary = 'fuel_tops'
+    type = TemperatureOutflowBC
+    variable = temp
+    velocity = '0 0 21.73'
+  [../]
+  [./vacuum_group1]
+    type = VacuumConcBC
+    boundary = 'fuel_bottoms fuel_tops moderator_bottoms moderator_tops'
+    variable = group1
+  [../]
+  [./vacuum_group2]
+    type = VacuumConcBC
+    boundary = 'fuel_bottoms fuel_tops moderator_bottoms moderator_tops'
+    variable = group2
+  [../]
+[]
+
+[Materials]
+  [./fuel]
+    type = GenericMoltresMaterial
+    property_tables_root = '../property_file_dir/newt_msre_fuel_'
+    interp_type = 'linear'
+    block = 'fuel'
+    prop_names = 'k cp rho'
+    prop_values = '.0553 1967 2.146e-3' # Robertson MSRE technical report @ 922 K
+    peak_power_density = peak_power_density
+    controller_gain = 1e-2
+  [../]
+  [./moder]
+    type = GenericMoltresMaterial
+    property_tables_root = '../property_file_dir/newt_msre_mod_'
+    interp_type = 'linear'
+    prop_names = 'k cp rho'
+    prop_values = '.312 1760 1.86e-3' # Cammi 2011 at 908 K
+    block = 'moderator'
+    peak_power_density = peak_power_density
+    controller_gain = 0
+  [../]
+[]
+
+[Debug]
+  show_var_residual_norms = true
+[]
+
+[Preconditioning]
+  [./SMP_PJFNK]
+    type = SMP
+    full = true
+    ksp_norm = 'none'
+  [../]
+[]
+
+# [Executioner]
+#   # type = Steady
+#   type = Transient
+#   dt = 1
+#   num_steps = 1
+#   petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount -ksp_type -snes_linesearch_minlambda'
+#   petsc_options_value = 'lu NONZERO 1.e-10 preonly 1e-3'
+#   petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_linesearch_monitor'
+#   # line_search = none
+#   nl_rel_tol = 1e-8
+#   nl_max_its = 50
+#   l_max_its = 300
+# []
+
+[Executioner]
+  type = Transient
+  end_time = 10000
+
+  nl_rel_tol = 1e-6
+  nl_abs_tol = 1e-6
+
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_linesearch_monitor'
+  # petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -sub_ksp_type -snes_linesearch_minlambda'
+  # petsc_options_value = 'asm      lu           1               preonly       1e-3'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount -ksp_type -snes_linesearch_minlambda'
+  petsc_options_value = 'lu NONZERO 1.e-10 preonly 1e-3'
+  # line_search = 'none'
+  # petsc_options_iname = '-snes_type'
+  # petsc_options_value = 'test'
+
+  nl_max_its = 30
+  l_max_its = 200
+
+#   dtmax = 1
+  dtmin = 1e-5
+  # dt = 1e-3
+  [./TimeStepper]
+    type = IterationAdaptiveDT
+    dt = 1e-5
+    cutback_factor = 0.4
+    growth_factor = 1.2
+    optimal_iterations = 20
+    linear_iteration_ratio = 1000
+  [../]
+[]
+
+[Outputs]
+  print_perf_log = true
+  exodus = true
+  csv = true
+  file_base = 'out'
+[]
+
+[Functions]
+  [./nt_ic]
+    type = ParsedFunction
+    value = '10 * sin(pi * z / ${length})'
+  [../]
+  [./temp_ic]
+    type = ParsedFunction
+    value = '900 + 100 / ${length} * z'
+  [../]
+[]
+
+[ICs]
+  [./temp]
+    type = FunctionIC
+    variable = temp
+    function = temp_ic
+  [../]
+  [./group1]
+    type = FunctionIC
+    variable = group1
+    function = nt_ic
+  [../]
+  [./group2]
+    type = FunctionIC
+    variable = group2
+    function = nt_ic
+  [../]
+[]
+
+# [MultiApps]
+#   [./sub]
+#     type = FullSolveMultiApp
+#     app_type = MoltresApp
+#     positions = '0 0 0'
+#     input_files = solution_aux_exodus.i
+#     execute_on = 'initial'
+#   [../]
+# []
+
+# [Transfers]
+#   [./vel_x]
+#     type = MultiAppNearestNodeTransfer
+#     direction = from_multiapp
+#     multi_app = sub
+#     source_variable = vel_x
+#     variable = vel_x
+#     execute_on = 'initial'
+#   [../]
+#   [./vel_y]
+#     type = MultiAppNearestNodeTransfer
+#     direction = from_multiapp
+#     multi_app = sub
+#     source_variable = vel_y
+#     variable = vel_y
+#     execute_on = 'initial'
+#   [../]
+#   [./vel_z]
+#     type = MultiAppNearestNodeTransfer
+#     direction = from_multiapp
+#     multi_app = sub
+#     source_variable = vel_z
+#     variable = vel_z
+#     execute_on = 'initial'
+#   [../]
+#   [./p]
+#     type = MultiAppNearestNodeTransfer
+#     direction = from_multiapp
+#     multi_app = sub
+#     source_variable = p
+#     variable = p
+#     execute_on = 'initial'
+#   [../]
+# []
+
+[Postprocessors]
+  [./group1_current]
+    type = IntegralNewVariablePostprocessor
+    variable = group1
+    # outputs = 'console csv'
+  [../]
+  [./group1_old]
+    type = IntegralOldVariablePostprocessor
+    variable = group1
+    # outputs = 'console csv'
+  [../]
+  [./multiplication]
+    type = DivisionPostprocessor
+    value1 = group1_current
+    value2 = group1_old
+    outputs = 'console csv'
+  [../]
+  [./temp_fuel]
+    type = ElementAverageValue
+    variable = temp
+    block = 'fuel'
+    outputs = 'csv console'
+  [../]
+  [./temp_moder]
+    type = ElementAverageValue
+    variable = temp
+    block = 'moderator'
+    outputs = 'csv console'
+  [../]
+  [./average_fission_heat]
+    type = AverageFissionHeat
+    execute_on = 'linear nonlinear'
+    outputs = 'console'
+    block = 'fuel'
+  [../]
+  [./peak_power_density]
+    type = ElementExtremeValue
+    value_type = max
+    variable = power_density
+    execute_on = 'linear nonlinear timestep_begin'
+  [../]
+[]

--- a/problems/MooseGold/single_msre_channel_velocity_heat_nts/unit-cell-nts-eigenvalue.i
+++ b/problems/MooseGold/single_msre_channel_velocity_heat_nts/unit-cell-nts-eigenvalue.i
@@ -18,7 +18,7 @@ nt_scale=1e13
 []
 
 [Mesh]
-  file = single_channel_msre_dimensions.msh
+  file = msre_squares.msh
 []
 
 
@@ -112,13 +112,13 @@ nt_scale=1e13
 [BCs]
   [./vacuum_group1]
     type = VacuumConcBC
-    boundary = 'fuel_bottom fuel_top moderator_bottoms moderator_tops'
+    boundary = 'fuel_bottoms fuel_tops moderator_bottoms moderator_tops'
     # boundary = 'fuel_bottom moderator_bottoms'
     variable = group1
   [../]
   [./vacuum_group2]
     type = VacuumConcBC
-    boundary = 'fuel_bottom fuel_top moderator_bottoms moderator_tops'
+    boundary = 'fuel_bottoms fuel_tops moderator_bottoms moderator_tops'
     # boundary = 'fuel_bottom moderator_bottoms'
     variable = group2
   [../]

--- a/problems/MooseGold/single_msre_channel_velocity_only/build.txt
+++ b/problems/MooseGold/single_msre_channel_velocity_only/build.txt
@@ -1,0 +1,56 @@
+Info    : Running 'gmsh -3 -order 2 half-fuel-channel-msre-dimensions.geo' [Gmsh 2.16.0, 1 node, max. 1 thread]
+Info    : Started on Fri Jun 30 11:55:42 2017
+Info    : Reading 'half-fuel-channel-msre-dimensions.geo'...
+Info    : Done reading 'half-fuel-channel-msre-dimensions.geo'
+Info    : Finalized high order topology of periodic connections
+Info    : Meshing 1D...
+Info    : Meshing curve 1 (Line)
+Info    : Meshing curve 2 (Line)
+Info    : Meshing curve 3 (Line)
+Info    : Meshing curve 4 (Line)
+Info    : Meshing curve 5 (Line)
+Info    : Meshing curve 6 (Line)
+Info    : Meshing curve 7 (Line)
+Info    : Meshing curve 8 (Line)
+Info    : Meshing curve 9 (Line)
+Info    : Meshing curve 10 (Line)
+Info    : Meshing curve 11 (Line)
+Info    : Meshing curve 12 (Line)
+Info    : Done meshing 1D (0.028 s)
+Info    : Meshing 2D...
+Info    : Meshing surface 14 (transfinite)
+Info    : Meshing surface 16 (transfinite)
+Info    : Meshing surface 18 (transfinite)
+Info    : Meshing surface 20 (transfinite)
+Info    : Meshing surface 22 (transfinite)
+Info    : Meshing surface 24 (transfinite)
+Info    : Done meshing 2D (0.000466108 s)
+Info    : Meshing 3D...
+Info    : Meshing volume 26 (transfinite)
+Info    : Done meshing 3D (0 s)
+Info    : Meshing order 2 (curvilinear on)...
+Info    : Meshing curve 1 order 2
+Info    : Meshing curve 2 order 2
+Info    : Meshing curve 3 order 2
+Info    : Meshing curve 4 order 2
+Info    : Meshing curve 5 order 2
+Info    : Meshing curve 6 order 2
+Info    : Meshing curve 7 order 2
+Info    : Meshing curve 8 order 2
+Info    : Meshing curve 9 order 2
+Info    : Meshing curve 10 order 2
+Info    : Meshing curve 11 order 2
+Info    : Meshing curve 12 order 2
+Info    : Meshing surface 14 order 2
+Info    : Meshing surface 16 order 2
+Info    : Meshing surface 18 order 2
+Info    : Meshing surface 20 order 2
+Info    : Meshing surface 22 order 2
+Info    : Meshing surface 24 order 2
+Info    : Meshing volume 26 order 2
+Info    : Finalized high order topology of periodic connections
+Info    : Done meshing order 2 (0.036 s)
+Info    : 19175 vertices 3472 elements
+Info    : Writing 'half-fuel-channel-msre-dimensions.msh'...
+Info    : Done writing 'half-fuel-channel-msre-dimensions.msh'
+Info    : Stopped on Fri Jun 30 11:55:42 2017

--- a/problems/MooseGold/single_msre_channel_velocity_only/fuel-half-channel-msre-dimensions-fluid-flow.i
+++ b/problems/MooseGold/single_msre_channel_velocity_only/fuel-half-channel-msre-dimensions-fluid-flow.i
@@ -1,0 +1,180 @@
+# This input file tests outflow boundary conditions for the incompressible NS equations.
+width = 3.048
+height = 1.016
+
+[GlobalParams]
+  gravity = '0 0 0'
+  integrate_p_by_parts = false
+[]
+
+[Mesh]
+  file = half-fuel-channel-msre-dimensions.msh
+[]
+
+
+[Variables]
+  [./vel_x]
+    order = SECOND
+    family = LAGRANGE
+  [../]
+  [./vel_y]
+    order = SECOND
+    family = LAGRANGE
+  [../]
+  [./vel_z]
+    order = SECOND
+    family = LAGRANGE
+  [../]
+  [./p]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./mass]
+    type = INSMass
+    variable = p
+    u = vel_x
+    v = vel_y
+    w = vel_z
+    p = p
+  [../]
+  [./x_momentum_space]
+    type = INSMomentumLaplaceForm
+    variable = vel_x
+    u = vel_x
+    v = vel_y
+    w = vel_z
+    p = p
+    component = 0
+  [../]
+  [./y_momentum_space]
+    type = INSMomentumLaplaceForm
+    variable = vel_y
+    u = vel_x
+    v = vel_y
+    w = vel_z
+    p = p
+    component = 1
+  [../]
+  [./z_momentum_space]
+    type = INSMomentumLaplaceForm
+    variable = vel_z
+    u = vel_x
+    v = vel_y
+    w = vel_z
+    p = p
+    component = 2
+  [../]
+[]
+
+[BCs]
+  # [./p_pin]
+  #   type = DirichletBC
+  #   value = 0
+  #   variable = p
+  #   boundary = 'corner'
+  # [../]
+  [./x_no_slip]
+    type = DirichletBC
+    variable = vel_x
+    boundary = 'bottom left right back'
+    value = 0.0
+  [../]
+  [./y_no_slip]
+    type = DirichletBC
+    variable = vel_y
+    boundary = 'top left bottom right back'
+    value = 0.0
+  [../]
+  [./z_no_slip]
+    type = DirichletBC
+    variable = vel_z
+    boundary = 'left bottom right'
+    value = 0
+  [../]
+  [./z_inlet]
+    type = FunctionDirichletBC
+    variable = vel_z
+    boundary = 'back'
+    function = 'inlet_func'
+  [../]
+[]
+
+[Materials]
+  [./const]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'rho mu'
+    prop_values = '2.15e-3  8.28e-5'
+    # prop_values = '1 2'
+  [../]
+[]
+
+[Debug]
+  show_var_residual_norms = true
+[]
+
+[Preconditioning]
+  [./SMP_PJFNK]
+    type = SMP
+    full = true
+    solve_type = NEWTON
+    ksp_norm = none
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  # type = Transient
+  # dt = 5e-5
+  # num_steps = 5
+  # petsc_options_iname = '-ksp_gmres_restart -pc_type -sub_pc_type' # -sub_pc_factor_levels'
+  # petsc_options_value = '300                bjacobi  ilu' #          4'
+  # petsc_options_iname = '-pc_type -sub_pc_type'
+  # petsc_options_value = 'asm	  lu'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount -ksp_type -snes_linesearch_minlambda'
+  petsc_options_value = 'lu NONZERO 1.e-10 preonly 1e-3'
+  petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_linesearch_monitor'
+  # line_search = none
+  nl_rel_tol = 1e-8
+  nl_max_its = 50
+  l_max_its = 300
+[]
+
+[Outputs]
+  [./out]
+    type = Exodus
+  [../]
+[]
+
+[Functions]
+  [./inlet_func]
+    type = ParsedFunction
+    # value = 'tanh(x/1e-2) * tanh((1 - x)/1e-2) * tanh(y/1e-2) * tanh((1-y)/1e-2)'
+    value = '21.73 * tanh(x/1e-2) * tanh((${width} - x)/1e-2) * tanh(y/1e-2) * tanh((${height}-y)/1e-2)'
+  [../]
+[]
+
+# [Adaptivity]
+#   marker = errorfrac_vel_z
+#   max_h_level = 2
+#   steps = 2
+#   [./Indicators]
+#     [./error_vel_z]
+#       type = GradientJumpIndicator
+#       variable = vel_z
+#       outputs = none
+#     [../]
+#   [../]
+#   [./Markers]
+#     [./errorfrac_vel_z]
+#       type = ErrorFractionMarker
+#       refine = 0.8
+#       coarsen = 0.1
+#       indicator = error_vel_z
+#       outputs = none
+#     [../]
+#   [../]
+# []

--- a/problems/MooseGold/single_msre_channel_velocity_only/half-fuel-channel-msre-dimensions.geo
+++ b/problems/MooseGold/single_msre_channel_velocity_only/half-fuel-channel-msre-dimensions.geo
@@ -1,0 +1,109 @@
+Geometry.CopyMeshingMethod = 1;
+// Mesh.RandomFactor = 1e-6;
+fuel_width = 3.048;
+fuel_height = .508;
+// fuel_length = 162.56;
+fuel_length = 16;
+lc = .1 * fuel_length;
+
+Point(1) = {0, 0, 0, lc};
+Point(2) = {0, 0, fuel_length, lc};
+
+// z-normal
+Line(1) = {1, 2};
+
+//+
+Point(3) = {fuel_width, 0, 0, 1.0};
+//+
+Point(4) = {fuel_width, fuel_height, 0, 1.0};
+//+
+Point(5) = {0, fuel_height, 0, 1.0};
+//+
+Point(6) = {fuel_width, fuel_height, fuel_length, 1.0};
+//+
+Point(7) = {fuel_width, 0, fuel_length, 1.0};
+//+
+Point(8) = {0, fuel_height, fuel_length, 1.0};
+//+
+Line(2) = {1, 5};
+//+
+Line(3) = {5, 4};
+//+
+Line(4) = {4, 3};
+//+ z-normal
+Line(5) = {3, 7};
+//+
+Line(6) = {3, 1};
+//+ z-normal
+Line(7) = {4, 6};
+//+
+Line(8) = {6, 7};
+//+
+Line(9) = {7, 2};
+//+
+Line(10) = {2, 8};
+//+
+Line(11) = {8, 6};
+//+ z-normal
+Line(12) = {5, 8};
+
+// z lines
+// Transfinite Line{1, 5, 7, 12} = 31 Using Progression 1.3;
+Transfinite Line{1, 5, 7, 12} = 20 Using Progression 1.2;
+// x lines
+Transfinite Line{3, 6, 9, 11} = 7 Using Bump 0.05;
+// y lines
+// Transfinite Line {2, -4, -8, 10} = 13 Using Progression 1.1;
+Transfinite Line {2, -4, -8, 10} = 13 Using Progression 1.1;
+
+
+// Point(3) = {fuel_width / 2., fuel_height / 2., 0, lc};
+//+
+Line Loop(13) = {5, 9, -1, -6};
+//+
+Plane Surface(14) = {13};
+//+
+Line Loop(15) = {2, 12, -10, -1};
+//+
+Plane Surface(16) = {15};
+//+
+Line Loop(17) = {11, -7, -3, 12};
+//+
+Plane Surface(18) = {17};
+//+
+Line Loop(19) = {7, 8, -5, -4};
+//+
+Plane Surface(20) = {19};
+//+
+Line Loop(21) = {8, 9, 10, 11};
+//+
+Plane Surface(22) = {21};
+//+
+Line Loop(23) = {3, 4, 6, 2};
+//+
+Plane Surface(24) = {23};
+//+
+Surface Loop(25) = {18, 22, 20, 14, 16, 24};
+//+
+Volume(26) = {25};
+
+Transfinite Surface{14, 16, 18, 20, 22, 24};
+Recombine Surface{14, 16, 18, 20, 22, 24};
+Transfinite Volume{26};
+Recombine Volume{26};
+//+
+Physical Surface("left") = {16};
+//+
+Physical Surface("right") = {20};
+//+
+Physical Surface("top") = {18};
+//+
+Physical Surface("bottom") = {14};
+//+
+Physical Surface("back") = {24};
+//+
+Physical Surface("front") = {22};
+//+
+Physical Volume(0) = {26};
+
+Physical Point("corner") = {1};

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -41,6 +41,8 @@
 #include "CammiFuel.h"
 #include "CammiModerator.h"
 #include "Nusselt.h"
+#include "GraphiteTwoGrpXSFunctionMaterial.h"
+#include "MsreFuelTwoGrpXSFunctionMaterial.h"
 
 // Postprocessors
 #include "AverageFissionHeat.h"
@@ -143,6 +145,8 @@ MoltresApp::registerObjects(Factory & factory)
   registerMaterial(CammiFuel);
   registerMaterial(CammiModerator);
   registerMaterial(Nusselt);
+  registerMaterial(GraphiteTwoGrpXSFunctionMaterial);
+  registerMaterial(MsreFuelTwoGrpXSFunctionMaterial);
   registerPostprocessor(IntegralOldVariablePostprocessor);
   registerPostprocessor(ElementL2Diff);
   registerPostprocessor(IntegralNewVariablePostprocessor);

--- a/src/materials/GenericMoltresMaterial.C
+++ b/src/materials/GenericMoltresMaterial.C
@@ -829,7 +829,7 @@ GenericMoltresMaterial::computeQpProperties()
   else if (_interp_type == "none")
     dummyComputeQpProperties();
 
-  if (_perform_control)
+  if (_perform_control && _peak_power_density > _peak_power_density_set_point)
     for (unsigned i = 0; i < _num_groups; ++i)
       _remxs[_qp][i] += _controller_gain * (_peak_power_density - _peak_power_density_set_point);
 }

--- a/src/materials/GraphiteTwoGrpXSFunctionMaterial.C
+++ b/src/materials/GraphiteTwoGrpXSFunctionMaterial.C
@@ -1,0 +1,135 @@
+#include "GraphiteTwoGrpXSFunctionMaterial.h"
+#include "MooseUtils.h"
+// #define PRINT(var) #var
+
+template <>
+InputParameters
+validParams<GraphiteTwoGrpXSFunctionMaterial>()
+{
+  InputParameters params = validParams<GenericConstantMaterial>();
+  params.addCoupledVar(
+      "temperature", 937, "The temperature field for determining group constants.");
+  return params;
+}
+
+GraphiteTwoGrpXSFunctionMaterial::GraphiteTwoGrpXSFunctionMaterial(
+    const InputParameters & parameters)
+  : GenericConstantMaterial(parameters),
+    _T(coupledValue("temperature")),
+    // _rho(getMaterialProperty<Real>("rho")),
+    _remxs(declareProperty<std::vector<Real>>("remxs")),
+    _fissxs(declareProperty<std::vector<Real>>("fissxs")),
+    _nsf(declareProperty<std::vector<Real>>("nsf")),
+    _fisse(declareProperty<std::vector<Real>>("fisse")),
+    _diffcoef(declareProperty<std::vector<Real>>("diffcoef")),
+    _recipvel(declareProperty<std::vector<Real>>("recipvel")),
+    _chi(declareProperty<std::vector<Real>>("chi")),
+    _gtransfxs(declareProperty<std::vector<Real>>("gtransfxs")),
+    _beta_eff(declareProperty<std::vector<Real>>("beta_eff")),
+    _beta(declareProperty<Real>("beta")),
+    _decay_constant(declareProperty<std::vector<Real>>("decay_constant")),
+
+    _d_remxs_d_temp(declareProperty<std::vector<Real>>("d_remxs_d_temp")),
+    _d_fissxs_d_temp(declareProperty<std::vector<Real>>("d_fissxs_d_temp")),
+    _d_nsf_d_temp(declareProperty<std::vector<Real>>("d_nsf_d_temp")),
+    _d_fisse_d_temp(declareProperty<std::vector<Real>>("d_fisse_d_temp")),
+    _d_diffcoef_d_temp(declareProperty<std::vector<Real>>("d_diffcoef_d_temp")),
+    _d_recipvel_d_temp(declareProperty<std::vector<Real>>("d_recipvel_d_temp")),
+    _d_chi_d_temp(declareProperty<std::vector<Real>>("d_chi_d_temp")),
+    _d_gtransfxs_d_temp(declareProperty<std::vector<Real>>("d_gtransfxs_d_temp")),
+    _d_beta_eff_d_temp(declareProperty<std::vector<Real>>("d_beta_eff_d_temp")),
+    _d_beta_d_temp(declareProperty<Real>("d_beta_d_temp")),
+    _d_decay_constant_d_temp(declareProperty<std::vector<Real>>("d_decay_constant_d_temp"))
+{
+}
+
+void
+GraphiteTwoGrpXSFunctionMaterial::computeQpProperties()
+{
+  for (unsigned int i = 0; i < _num_props; i++)
+    (*_properties[i])[_qp] = _prop_values[i];
+
+  _remxs[_qp].resize(2, 0);
+  _fissxs[_qp].resize(2, 0);
+  _nsf[_qp].resize(2, 0);
+  _fisse[_qp].resize(2, 0);
+  _diffcoef[_qp].resize(2, 0);
+  _recipvel[_qp].resize(2, 0);
+  _chi[_qp].resize(2, 0);
+  _gtransfxs[_qp].resize(4, 0);
+  _beta_eff[_qp].resize(6, 0);
+  _decay_constant[_qp].resize(6, 0);
+  _d_remxs_d_temp[_qp].resize(2, 0);
+  _d_fissxs_d_temp[_qp].resize(2, 0);
+  _d_nsf_d_temp[_qp].resize(2, 0);
+  _d_fisse_d_temp[_qp].resize(2, 0);
+  _d_diffcoef_d_temp[_qp].resize(2, 0);
+  _d_recipvel_d_temp[_qp].resize(2, 0);
+  _d_chi_d_temp[_qp].resize(2, 0);
+  _d_gtransfxs_d_temp[_qp].resize(4, 0);
+  _d_beta_eff_d_temp[_qp].resize(6, 0);
+  _d_decay_constant_d_temp[_qp].resize(6, 0);
+
+  Real T0 = 922;
+  Real rho0 = 1.86e-3;
+  Real rho = rho0 * std::exp(-1.8 * 1.0e-5 * (_T[_qp] - T0));
+  Real d_rho_d_T = rho * -1.8 * 1.0e-5;
+
+  // Constants taken from newt_msre property text files
+  _remxs[_qp][0] = (4.26E-03 + 3.78E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _remxs[_qp][1] = (3.11E-03 + 8.38E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _diffcoef[_qp][0] = (9.85E-01 + 8.23E-03 * std::log(_T[_qp] / T0)) * rho0 / rho;
+  _diffcoef[_qp][1] = (7.70E-01 + 3.38E-03 * std::log(_T[_qp] / T0)) * rho0 / rho;
+  _gtransfxs[_qp][0] = (3.94E-01 + -7.85E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][1] = (2.96E-03 + 8.43E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][2] = (4.25E-03 + 3.78E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][3] = (4.55E-01 + -1.05E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _recipvel[_qp][0] = 9.98E-08 + 2.21E-08 * std::log(_T[_qp] / T0);
+  _recipvel[_qp][1] = 2.08E-06 + -7.19E-07 * std::log(_T[_qp] / T0);
+
+  _d_remxs_d_temp[_qp][0] =
+      (3.78E-03 / _T[_qp] * rho + (4.26E-03 + 3.78E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_remxs_d_temp[_qp][1] =
+      (8.38E-03 / _T[_qp] * rho + (3.11E-03 + 8.38E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_diffcoef_d_temp[_qp][0] =
+      (8.23E-03 / _T[_qp] / rho +
+       (9.85E-01 + 8.23E-03 * std::log(_T[_qp] / T0)) * -d_rho_d_T / (rho * rho)) *
+      rho0;
+  _d_diffcoef_d_temp[_qp][1] =
+      (3.38E-03 / _T[_qp] / rho +
+       (7.70E-01 + 3.38E-03 * std::log(_T[_qp] / T0)) * -d_rho_d_T / (rho * rho)) *
+      rho0;
+  _d_gtransfxs_d_temp[_qp][0] =
+      (-7.85E-03 / _T[_qp] * rho + (3.94E-01 + -7.85E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][1] =
+      (8.43E-03 / _T[_qp] * rho + (2.96E-03 + 8.43E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][2] =
+      (3.78E-03 / _T[_qp] * rho + (4.25E-03 + 3.78E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][3] =
+      (-1.05E-02 / _T[_qp] * rho + (4.55E-01 + -1.05E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_recipvel_d_temp[_qp][0] = 2.21E-08 / _T[_qp];
+  _d_recipvel_d_temp[_qp][1] = -7.19E-07 / _T[_qp];
+
+  _beta[_qp] = 0;
+  _d_beta_d_temp[_qp] = 0;
+  for (unsigned i = 0; i < 2; i++)
+  {
+    _nsf[_qp][i] = 0;
+    _fissxs[_qp][i] = 0;
+    _d_nsf_d_temp[_qp][i] = 0;
+    _d_fissxs_d_temp[_qp][i] = 0;
+  }
+  for (unsigned i = 0; i < 6; i++)
+  {
+    _beta_eff[_qp][i] = 0;
+    _decay_constant[_qp][i] = 0;
+    _d_beta_eff_d_temp[_qp][i] = 0;
+    _d_decay_constant_d_temp[_qp][i] = 0;
+  }
+}

--- a/src/materials/MsreFuelTwoGrpXSFunctionMaterial.C
+++ b/src/materials/MsreFuelTwoGrpXSFunctionMaterial.C
@@ -1,0 +1,156 @@
+#include "MsreFuelTwoGrpXSFunctionMaterial.h"
+#include "MooseUtils.h"
+// #define PRINT(var) #var
+
+template <>
+InputParameters
+validParams<MsreFuelTwoGrpXSFunctionMaterial>()
+{
+  InputParameters params = validParams<GenericConstantMaterial>();
+  params.addCoupledVar(
+      "temperature", 937, "The temperature field for determining group constants.");
+  return params;
+}
+
+MsreFuelTwoGrpXSFunctionMaterial::MsreFuelTwoGrpXSFunctionMaterial(
+    const InputParameters & parameters)
+  : GenericConstantMaterial(parameters),
+    _T(coupledValue("temperature")),
+    // _rho(getMaterialProperty<Real>("rho")),
+    _remxs(declareProperty<std::vector<Real>>("remxs")),
+    _fissxs(declareProperty<std::vector<Real>>("fissxs")),
+    _nsf(declareProperty<std::vector<Real>>("nsf")),
+    _fisse(declareProperty<std::vector<Real>>("fisse")),
+    _diffcoef(declareProperty<std::vector<Real>>("diffcoef")),
+    _recipvel(declareProperty<std::vector<Real>>("recipvel")),
+    _chi(declareProperty<std::vector<Real>>("chi")),
+    _gtransfxs(declareProperty<std::vector<Real>>("gtransfxs")),
+    _beta_eff(declareProperty<std::vector<Real>>("beta_eff")),
+    _beta(declareProperty<Real>("beta")),
+    _decay_constant(declareProperty<std::vector<Real>>("decay_constant")),
+
+    _d_remxs_d_temp(declareProperty<std::vector<Real>>("d_remxs_d_temp")),
+    _d_fissxs_d_temp(declareProperty<std::vector<Real>>("d_fissxs_d_temp")),
+    _d_nsf_d_temp(declareProperty<std::vector<Real>>("d_nsf_d_temp")),
+    _d_fisse_d_temp(declareProperty<std::vector<Real>>("d_fisse_d_temp")),
+    _d_diffcoef_d_temp(declareProperty<std::vector<Real>>("d_diffcoef_d_temp")),
+    _d_recipvel_d_temp(declareProperty<std::vector<Real>>("d_recipvel_d_temp")),
+    _d_chi_d_temp(declareProperty<std::vector<Real>>("d_chi_d_temp")),
+    _d_gtransfxs_d_temp(declareProperty<std::vector<Real>>("d_gtransfxs_d_temp")),
+    _d_beta_eff_d_temp(declareProperty<std::vector<Real>>("d_beta_eff_d_temp")),
+    _d_beta_d_temp(declareProperty<Real>("d_beta_d_temp")),
+    _d_decay_constant_d_temp(declareProperty<std::vector<Real>>("d_decay_constant_d_temp"))
+{
+}
+
+void
+MsreFuelTwoGrpXSFunctionMaterial::computeQpProperties()
+{
+  for (unsigned int i = 0; i < _num_props; i++)
+    (*_properties[i])[_qp] = _prop_values[i];
+
+  _remxs[_qp].resize(2, 0);
+  _fissxs[_qp].resize(2, 0);
+  _nsf[_qp].resize(2, 0);
+  _fisse[_qp].resize(2, 0);
+  _diffcoef[_qp].resize(2, 0);
+  _recipvel[_qp].resize(2, 0);
+  _chi[_qp].resize(2, 0);
+  _gtransfxs[_qp].resize(4, 0);
+  _beta_eff[_qp].resize(6, 0);
+  _decay_constant[_qp].resize(6, 0);
+  _d_remxs_d_temp[_qp].resize(2, 0);
+  _d_fissxs_d_temp[_qp].resize(2, 0);
+  _d_nsf_d_temp[_qp].resize(2, 0);
+  _d_fisse_d_temp[_qp].resize(2, 0);
+  _d_diffcoef_d_temp[_qp].resize(2, 0);
+  _d_recipvel_d_temp[_qp].resize(2, 0);
+  _d_chi_d_temp[_qp].resize(2, 0);
+  _d_gtransfxs_d_temp[_qp].resize(4, 0);
+  _d_beta_eff_d_temp[_qp].resize(6, 0);
+  _d_decay_constant_d_temp[_qp].resize(6, 0);
+
+  Real T0 = 922;
+  Real rho0 = 2.146e-3;
+  Real rho = rho0 * std::exp(-1.8 * 1.18e-4 * (_T[_qp] - T0));
+  Real d_rho_d_T = rho * -1.8 * 1.18e-4;
+
+  // Constants taken from newt_msre property text files
+  _nsf[_qp][0] = (3.18E-03 + -3.46E-04 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _nsf[_qp][1] = (5.30E-02 + -2.97E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _remxs[_qp][0] = (5.72E-03 + 1.15E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _remxs[_qp][1] = (2.86E-02 + -1.09E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _fissxs[_qp][0] = (1.30E-03 + -1.41E-04 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _fissxs[_qp][1] = (2.18E-02 + -1.22E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _diffcoef[_qp][0] = (1.43E+00 + 2.91E-01 * std::log(_T[_qp] / T0)) * rho0 / rho;
+  _diffcoef[_qp][1] = (1.26E+00 + 2.92E-01 * std::log(_T[_qp] / T0)) * rho0 / rho;
+  _gtransfxs[_qp][0] = (2.66E-01 + -5.57E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][1] = (1.59E-03 + 3.90E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][2] = (2.02E-03 + 1.44E-03 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _gtransfxs[_qp][3] = (2.49E-01 + -5.23E-02 * std::log(_T[_qp] / T0)) * rho / rho0;
+  _recipvel[_qp][0] = 9.69E-08 + 2.18E-08 * std::log(_T[_qp] / T0);
+  _recipvel[_qp][1] = 2.06E-06 + -6.95E-07 * std::log(_T[_qp] / T0);
+
+  _d_nsf_d_temp[_qp][0] =
+      (-3.46E-04 / _T[_qp] * rho + (3.18E-03 + -3.46E-04 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_nsf_d_temp[_qp][1] =
+      (-2.97E-02 / _T[_qp] * rho + (5.30E-02 + -2.97E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_remxs_d_temp[_qp][0] =
+      (1.15E-03 / _T[_qp] * rho + (5.72E-03 + 1.15E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_remxs_d_temp[_qp][1] =
+      (-1.09E-02 / _T[_qp] * rho + (2.86E-02 + -1.09E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_fissxs_d_temp[_qp][0] =
+      (-1.41E-04 / _T[_qp] * rho + (1.30E-03 + -1.41E-04 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_fissxs_d_temp[_qp][1] =
+      (-1.22E-02 / _T[_qp] * rho + (2.18E-02 + -1.22E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_diffcoef_d_temp[_qp][0] =
+      (2.91E-01 / _T[_qp] / rho +
+       (1.43E+00 + 2.91E-01 * std::log(_T[_qp] / T0)) * -d_rho_d_T / (rho * rho)) *
+      rho0;
+  _d_diffcoef_d_temp[_qp][1] =
+      (2.92E-01 / _T[_qp] / rho +
+       (1.26E+00 + 2.92E-01 * std::log(_T[_qp] / T0)) * -d_rho_d_T / (rho * rho)) *
+      rho0;
+  _d_gtransfxs_d_temp[_qp][0] =
+      (-5.57E-02 / _T[_qp] * rho + (2.66E-01 + -5.57E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][1] =
+      (3.90E-03 / _T[_qp] * rho + (1.59E-03 + 3.90E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][2] =
+      (1.44E-03 / _T[_qp] * rho + (2.02E-03 + 1.44E-03 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_gtransfxs_d_temp[_qp][3] =
+      (-5.23E-02 / _T[_qp] * rho + (2.49E-01 + -5.23E-02 * std::log(_T[_qp] / T0)) * d_rho_d_T) /
+      rho0;
+  _d_recipvel_d_temp[_qp][0] = 2.18E-08 / _T[_qp];
+  _d_recipvel_d_temp[_qp][1] = -6.95E-07 / _T[_qp];
+
+  _fisse[_qp][0] = 194. * 1e6 * 1.6e-19; // convert MeV to Joules
+  _fisse[_qp][1] = 194. * 1e6 * 1.6e-19; // convert MeV to Joules
+  _chi[_qp][0] = 1;
+  _chi[_qp][1] = 0;
+  _beta_eff[_qp][0] = 2.37e-4;
+  _beta_eff[_qp][1] = 1.54e-3;
+  _beta_eff[_qp][2] = 1.38e-3;
+  _beta_eff[_qp][3] = 2.80e-3;
+  _beta_eff[_qp][4] = 8.26e-4;
+  _beta_eff[_qp][5] = 2.86e-4;
+  _beta[_qp] = 0;
+  for (unsigned i = 0; i < 6; i++)
+    _beta[_qp] += _beta_eff[_qp][i];
+  _d_beta_d_temp[_qp] = 0;
+
+  _decay_constant[_qp][0] = 1.24e-2;
+  _decay_constant[_qp][1] = 3.06e-2;
+  _decay_constant[_qp][2] = 1.11e-1;
+  _decay_constant[_qp][3] = 3.02e-1;
+  _decay_constant[_qp][4] = 1.17e0;
+  _decay_constant[_qp][5] = 3.07e0;
+}

--- a/src/materials/required_xs.md
+++ b/src/materials/required_xs.md
@@ -1,0 +1,12 @@
+The following are required cross sections for Moltres:
+
+- fissxs
+- remxs
+- nsf
+- fisse
+- diffcoef
+- recipvel
+- chi
+- gtransfxs
+- beta\_eff
+- decay\_constant

--- a/tests/twod_axi_coupled/auto_diff_rho.i
+++ b/tests/twod_axi_coupled/auto_diff_rho.i
@@ -219,9 +219,10 @@ diri_temp=922
 
   solve_type = 'NEWTON'
   petsc_options = '-snes_converged_reason -ksp_converged_reason -snes_linesearch_monitor'
-  petsc_options_iname = '-pc_type -sub_pc_type -pc_asm_overlap -sub_ksp_type -snes_linesearch_minlambda'
-  petsc_options_value = 'asm      lu           1               preonly       1e-3'
-  # petsc_options_iname = '-snes_type'
+  petsc_options_iname = '-pc_type -pc_factor_shift_type -pc_factor_shift_amount -ksp_type -snes_linesearch_minlambda'
+  petsc_options_value = 'lu       NONZERO               1e-10                   preonly   1e-3'
+  line_search = 'none'
+   # petsc_options_iname = '-snes_type'
   # petsc_options_value = 'test'
 
   nl_max_its = 30
@@ -243,6 +244,7 @@ diri_temp=922
   [./SMP]
     type = SMP
     full = true
+    ksp_norm = none
   [../]
 []
 


### PR DESCRIPTION
The new function materials:

- GraphiteTwoGrpXSFunctionMaterial
- MsreFuelTwoGrpXSFunctionMaterial

provide slightly different results compared to using `GenericMoltresMaterial` but they speed-up two-d axi simulation by a factor of four. Moreover, "slightly different" results in the context of a steady-state simulation without control rods is really more or less an exact match.

In this commit, I also rewrote the coupled test to use `lu` and no line search so it's faster by a factor of 2.5. In the future may add a test using the new function materials or replace the current coupled test to use the function materials.