### PR TITLE
changed PrecursorKernel action to Precursors in all files

### DIFF
--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -1,12 +1,12 @@
-#ifndef PRECURSORKERNELACTION_H
-#define PRECURSORKERNELACTION_H
+#ifndef PRECURSORACTION_H
+#define PRECURSORACTION_H
 
 #include "AddVariableAction.h"
 
-class PrecursorKernelAction : public AddVariableAction
+class PrecursorAction : public AddVariableAction
 {
 public:
-  PrecursorKernelAction(const InputParameters & params);
+  PrecursorAction(const InputParameters & params);
 
   virtual void act();
 
@@ -25,6 +25,6 @@ protected:
 };
 
 template <>
-InputParameters validParams<PrecursorKernelAction>();
+InputParameters validParams<PrecursorAction>();
 
-#endif // PRECURSORKERNELACTION_H
+#endif // PRECURSORACTION_H

--- a/problems/011317_notebook_add_temperature_coupling/Input.i
+++ b/problems/011317_notebook_add_temperature_coupling/Input.i
@@ -33,7 +33,7 @@ global_temperature=temp
   # temperature_value = ${global_temperature}
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   inlet_boundary = 'fuel_bottom'

--- a/problems/011317_notebook_add_temperature_coupling/Input_serpent.i
+++ b/problems/011317_notebook_add_temperature_coupling/Input_serpent.i
@@ -33,7 +33,7 @@ global_temperature=900
   temperature_value = ${global_temperature}
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   inlet_boundary = 'fuel_bottom'

--- a/problems/011317_notebook_perfectly_bracketed_critical_buckling_height_from_newt/Input.i
+++ b/problems/011317_notebook_perfectly_bracketed_critical_buckling_height_from_newt/Input.i
@@ -33,7 +33,7 @@ global_temperature=950
   temperature_value = ${global_temperature}
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   inlet_boundary = 'fuel_bottom'

--- a/problems/011317_notebook_perfectly_bracketed_critical_buckling_height_from_newt/Input_serpent.i
+++ b/problems/011317_notebook_perfectly_bracketed_critical_buckling_height_from_newt/Input_serpent.i
@@ -33,7 +33,7 @@ global_temperature=900
   temperature_value = ${global_temperature}
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   inlet_boundary = 'fuel_bottom'

--- a/problems/011717_precursors/Input.i
+++ b/problems/011717_precursors/Input.i
@@ -33,7 +33,7 @@ global_temperature=temp
   # temperature_value = ${global_temperature}
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   inlet_boundary = 'fuel_bottom'

--- a/problems/011717_precursors/Input_restart_rdg_module.i
+++ b/problems/011717_precursors/Input_restart_rdg_module.i
@@ -35,7 +35,7 @@ global_temperature=temp
   init_temperature_from_file = true
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/012017_temperature_to_dg/Input.i
+++ b/problems/012017_temperature_to_dg/Input.i
@@ -31,7 +31,7 @@ sigma_val=6
   dg_for_temperature = true
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/012017_temperature_to_dg/test_mat_props.i
+++ b/problems/012017_temperature_to_dg/test_mat_props.i
@@ -31,7 +31,7 @@ sigma_val=6
   dg_for_temperature = true
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/020617_mod_heat_source_one_minus_beta_fission/Input.i
+++ b/problems/020617_mod_heat_source_one_minus_beta_fission/Input.i
@@ -31,7 +31,7 @@ sigma_val=6
   dg_for_temperature = true
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/020617_mod_heat_source_one_minus_beta_fission/Input_PJFNK.i
+++ b/problems/020617_mod_heat_source_one_minus_beta_fission/Input_PJFNK.i
@@ -31,7 +31,7 @@ sigma_val=6
   dg_for_temperature = true
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/021417_MSRE_materials/CG_temp.i
+++ b/problems/021417_MSRE_materials/CG_temp.i
@@ -30,7 +30,7 @@ global_temperature=temp
   dg_for_temperature = false
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/021417_MSRE_materials/Input.i
+++ b/problems/021417_MSRE_materials/Input.i
@@ -32,7 +32,7 @@ sigma_val=6
   dg_for_temperature = true
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/021417_MSRE_materials/mini_msre_cg_temp.i
+++ b/problems/021417_MSRE_materials/mini_msre_cg_temp.i
@@ -30,7 +30,7 @@ global_temperature=temp
   dg_for_temperature = false
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   advection_boundaries = 'fuel_top fuel_bottom'

--- a/problems/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections.i
@@ -51,7 +51,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
@@ -54,7 +54,7 @@ offset=2.5
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_direct.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_direct.i
@@ -43,7 +43,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_restart.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_restart.i
@@ -44,7 +44,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin.i
@@ -43,7 +43,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive.i
@@ -42,7 +42,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive_PJFNK.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive_PJFNK.i
@@ -42,7 +42,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function.i
@@ -43,7 +43,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function_moderator_heating.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function_moderator_heating.i
@@ -52,7 +52,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
@@ -54,7 +54,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
@@ -54,7 +54,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_monotone_interp.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_monotone_interp.i
@@ -42,7 +42,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/controlled_neutronics_only.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/controlled_neutronics_only.i
@@ -44,7 +44,7 @@ nt_scale=1e13
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/033117_nts_temp_pre_parsed_mat/meigen.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/meigen.i
@@ -38,7 +38,7 @@
 #  [../]
 #[]
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/060717_dimension_testing/one_group.i
+++ b/problems/060717_dimension_testing/one_group.i
@@ -35,7 +35,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/070517_4group/eigen/eigen.i
+++ b/problems/070517_4group/eigen/eigen.i
@@ -40,7 +40,7 @@ flow_velocity = 21.7
 #  #[../]
 #[]
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   block = 'fuel'
   outlet_boundaries = 'fuel_tops'

--- a/problems/072017_dg_temperature/auto_diff_rho.i
+++ b/problems/072017_dg_temperature/auto_diff_rho.i
@@ -53,7 +53,7 @@ sigma_val=.6
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/LOSCA/HXFailure/auto_diff_rho.i
+++ b/problems/LOSCA/HXFailure/auto_diff_rho.i
@@ -43,7 +43,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   block = 'fuel'

--- a/problems/LOSCA/HXFailure/sub.i
+++ b/problems/LOSCA/HXFailure/sub.i
@@ -29,7 +29,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   outlet_boundaries = 'right'

--- a/problems/LOSCA/auto_diff_rho.i
+++ b/problems/LOSCA/auto_diff_rho.i
@@ -40,7 +40,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   block = 'fuel'

--- a/problems/LOSCA/sub.i
+++ b/problems/LOSCA/sub.i
@@ -31,7 +31,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   outlet_boundaries = 'right'

--- a/problems/axi-nts-temp-delayed.i
+++ b/problems/axi-nts-temp-delayed.i
@@ -146,7 +146,7 @@ flow_velocity=147 # Cammi 147 cm/s
 
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   v_def = ${flow_velocity}
   block = 'fuel'

--- a/problems/constant_inlet_outlet_temp/auto_diff_rho.i
+++ b/problems/constant_inlet_outlet_temp/auto_diff_rho.i
@@ -40,7 +40,7 @@ H=162.56
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
+++ b/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
@@ -50,7 +50,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/debug-precursor-action.i
+++ b/problems/debug-precursor-action.i
@@ -174,7 +174,7 @@ flow_velocity=147 # Cammi 147 cm/s
   # [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   # v_def = ${flow_velocity}
   # block = 'fuel'

--- a/problems/publication_level_cases/3d_steady_state/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/3d_steady_state/3d_auto_diff_rho.i
@@ -54,7 +54,7 @@ offset=2.5
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/publication_level_cases/LOSCA/HXFail/auto_diff_rho.i
+++ b/problems/publication_level_cases/LOSCA/HXFail/auto_diff_rho.i
@@ -43,7 +43,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   block = 'fuel'

--- a/problems/publication_level_cases/LOSCA/HXFail/sub.i
+++ b/problems/publication_level_cases/LOSCA/HXFail/sub.i
@@ -29,7 +29,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   outlet_boundaries = 'right'

--- a/problems/publication_level_cases/LOSCA/auto_diff_rho.i
+++ b/problems/publication_level_cases/LOSCA/auto_diff_rho.i
@@ -40,7 +40,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   block = 'fuel'

--- a/problems/publication_level_cases/LOSCA/sub.i
+++ b/problems/publication_level_cases/LOSCA/sub.i
@@ -31,7 +31,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   outlet_boundaries = 'right'

--- a/problems/publication_level_cases/dilute_absorber_controlled_by_peak_power_density/in.i
+++ b/problems/publication_level_cases/dilute_absorber_controlled_by_peak_power_density/in.i
@@ -54,7 +54,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/publication_level_cases/gamma_heating_3d_ss/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/gamma_heating_3d_ss/3d_auto_diff_rho.i
@@ -54,7 +54,7 @@ offset=2.5
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/publication_level_cases/transient_single_channel_blockage/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/transient_single_channel_blockage/3d_auto_diff_rho.i
@@ -52,7 +52,7 @@ offset=2.5
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./primary_fuel]
     var_name_base = pre
     block = 'fuel blocked_fuel'

--- a/problems/publication_level_cases/transient_single_channel_blockage/3d_ss.i
+++ b/problems/publication_level_cases/transient_single_channel_blockage/3d_ss.i
@@ -49,7 +49,7 @@ offset=2.5
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./primary_fuel]
     var_name_base = pre
     block = 'fuel blocked_fuel'

--- a/problems/publication_level_cases/twod_control_rod_yank/rodded.i
+++ b/problems/publication_level_cases/twod_control_rod_yank/rodded.i
@@ -35,7 +35,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/rodded2D/rodded.i
+++ b/problems/rodded2D/rodded.i
@@ -35,7 +35,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'

--- a/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-channel-msre-dimensions.i
+++ b/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-channel-msre-dimensions.i
@@ -60,7 +60,7 @@ nt_scale=1e13
   [../]
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   outlet_boundaries = 'fuel_top'

--- a/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-unit-cell.i
+++ b/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-unit-cell.i
@@ -60,7 +60,7 @@ nt_scale=1e13
   [../]
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   outlet_boundaries = 'fuel_top'

--- a/problems/single_msre_channel_velocity_heat_nts/nts-eigenvalue-msre-channel-dimensions.i
+++ b/problems/single_msre_channel_velocity_heat_nts/nts-eigenvalue-msre-channel-dimensions.i
@@ -37,7 +37,7 @@ nt_scale=1e13
   [../]
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   outlet_boundaries = 'fuel_top'

--- a/problems/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
+++ b/problems/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
@@ -62,7 +62,7 @@ nt_scale=1e13
   [../]
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   outlet_boundaries = 'fuel_top'

--- a/problems/single_msre_channel_velocity_heat_nts/unit-cell-nts-eigenvalue.i
+++ b/problems/single_msre_channel_velocity_heat_nts/unit-cell-nts-eigenvalue.i
@@ -37,7 +37,7 @@ nt_scale=1e13
   [../]
 []
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   block = 'fuel'
 #   outlet_boundaries = 'fuel_top'

--- a/problems/transient-axi-nts-temp-delayed.i
+++ b/problems/transient-axi-nts-temp-delayed.i
@@ -130,7 +130,7 @@ nt_scale=1e18
 
 # Delayed neutron precursors
 
-# [PrecursorKernel]
+# [Precursors]
 #   var_name_base = pre
 #   v_def = ${flow_velocity}
 #   block = 'fuel'

--- a/problems/transient-jac-test.i
+++ b/problems/transient-jac-test.i
@@ -133,7 +133,7 @@ flow_velocity=147 # Cammi 147 cm/s
 
 # Delayed neutron precursors
 
-[PrecursorKernel]
+[Precursors]
   var_name_base = pre
   v_def = ${flow_velocity}
   # block = 'fuel'

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -1,4 +1,4 @@
-#include "PrecursorKernelAction.h"
+#include "PrecursorAction.h"
 #include "Factory.h"
 #include "Parser.h"
 #include "Conversion.h"
@@ -7,7 +7,7 @@
 
 template <>
 InputParameters
-validParams<PrecursorKernelAction>()
+validParams<PrecursorAction>()
 {
   InputParameters params = validParams<AddVariableAction>();
   params.addRequiredParam<unsigned int>("num_precursor_groups",
@@ -60,7 +60,7 @@ validParams<PrecursorKernelAction>()
   return params;
 }
 
-PrecursorKernelAction::PrecursorKernelAction(const InputParameters & params)
+PrecursorAction::PrecursorAction(const InputParameters & params)
   : AddVariableAction(params),
     _num_precursor_groups(getParam<unsigned int>("num_precursor_groups")),
     _var_name_base(getParam<std::string>("var_name_base")),
@@ -70,7 +70,7 @@ PrecursorKernelAction::PrecursorKernelAction(const InputParameters & params)
 }
 
 void
-PrecursorKernelAction::act()
+PrecursorAction::act()
 {
   for (unsigned int op = 1; op <= _num_precursor_groups; ++op)
   {

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -63,7 +63,7 @@
 #include "MatDiffusionAux.h"
 
 // Actions
-#include "PrecursorKernelAction.h"
+#include "PrecursorAction.h"
 #include "NtAction.h"
 
 // DiracKernels
@@ -177,16 +177,16 @@ MoltresApp__associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 void
 MoltresApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-  syntax.registerActionSyntax("PrecursorKernelAction", "PrecursorKernel/*");
+  syntax.registerActionSyntax("PrecursorAction", "Precursors/*");
   syntax.registerActionSyntax("NtAction", "Nt");
 
-  registerAction(PrecursorKernelAction, "add_kernel");
-  registerAction(PrecursorKernelAction, "add_bc");
-  registerAction(PrecursorKernelAction, "add_variable");
-  registerAction(PrecursorKernelAction, "add_ic");
-  registerAction(PrecursorKernelAction, "add_dg_kernel");
-  registerAction(PrecursorKernelAction, "check_copy_nodal_vars");
-  registerAction(PrecursorKernelAction, "copy_nodal_vars");
+  registerAction(PrecursorAction, "add_kernel");
+  registerAction(PrecursorAction, "add_bc");
+  registerAction(PrecursorAction, "add_variable");
+  registerAction(PrecursorAction, "add_ic");
+  registerAction(PrecursorAction, "add_dg_kernel");
+  registerAction(PrecursorAction, "check_copy_nodal_vars");
+  registerAction(PrecursorAction, "copy_nodal_vars");
   registerAction(NtAction, "add_kernel");
   registerAction(NtAction, "add_bc");
   registerAction(NtAction, "add_variable");

--- a/tests/diracHX/sub.i
+++ b/tests/diracHX/sub.i
@@ -35,7 +35,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
  [./core]
   var_name_base = pre
   outlet_boundaries = 'right'

--- a/tests/pre/pre.i
+++ b/tests/pre/pre.i
@@ -19,7 +19,7 @@ global_temperature=922
   kernel_coverage_check = false
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     outlet_boundaries = 'fuel_tops'

--- a/tests/twod_axi_coupled/auto_diff_rho.i
+++ b/tests/twod_axi_coupled/auto_diff_rho.i
@@ -42,7 +42,7 @@ diri_temp=922
   [../]
 []
 
-[PrecursorKernel]
+[Precursors]
   [./pres]
     var_name_base = pre
     block = 'fuel'


### PR DESCRIPTION
Since the PrecursorKernel action is being changed to Precursors, all input files containing "PrecursorKernel" were appropriately altered. In addition, the MoltresApp.C was changed in order to recognize syntax for the new action name.

Alex and I felt this was appropriate before adding any more functionality to the PrecursorKernel action.