### PR TITLE
Circulating delayed neutron precursor easy setup

### DIFF
--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -35,9 +35,6 @@ protected:
 
   /// optional object name suffix
   std::string _object_suffix;
-
-  /// name of multi app for precursor circulation
-  MultiAppName _multi_app;
 };
 
 template <>

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -22,6 +22,12 @@ public:
   PrecursorAction(const InputParameters & params);
 
   virtual void act();
+  virtual void kernelAct(const unsigned & op, const std::string & var_name);
+  virtual void bcAct(const std::string & var_name);
+  virtual void dgKernelAct(const std::string & var_name);
+  virtual void icAct(const std::string & var_name);
+  virtual void postAct(const std::string & var_name);
+  virtual void transferAct(const std::string & var_name);
 
 protected:
   /// number of precursor groups

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -35,6 +35,9 @@ protected:
 
   /// optional object name suffix
   std::string _object_suffix;
+
+  /// name of multi app for precursor circulation
+  MultiAppName _multi_app;
 };
 
 template <>

--- a/problems/LOSCA/HXFailure/auto_diff_rho.i
+++ b/problems/LOSCA/HXFailure/auto_diff_rho.i
@@ -59,7 +59,6 @@ diri_temp=922
   multi_app = loopApp
   is_loopapp = false
   inlet_boundaries = 'fuel_bottoms'
-
  [../]
 []
 

--- a/problems/LOSCA/HXFailure/auto_diff_rho.i
+++ b/problems/LOSCA/HXFailure/auto_diff_rho.i
@@ -55,6 +55,11 @@ diri_temp=922
   family = MONOMIAL
   order = CONSTANT
   init_from_file = true
+  loop_precs = true
+  multi_app = loopApp
+  is_loopapp = false
+  inlet_boundaries = 'fuel_bottoms'
+
  [../]
 []
 

--- a/problems/LOSCA/HXFailure/sub.i
+++ b/problems/LOSCA/HXFailure/sub.i
@@ -40,6 +40,10 @@ diri_temp=922
   family = MONOMIAL
   order = CONSTANT
   init_from_file = true
+  loop_precs = true
+  multi_app = loopApp
+  is_loopapp = true
+  inlet_boundaries = left
  [../]
 []
 

--- a/problems/LOSCA/auto_diff_rho.i
+++ b/problems/LOSCA/auto_diff_rho.i
@@ -51,6 +51,10 @@ diri_temp=922
   nt_exp_form = false
   family = MONOMIAL
   order = CONSTANT
+  loop_precs = true
+  multi_app = loopApp
+  is_loopapp = false
+  inlet_boundaries = 'fuel_bottoms'
  [../]
 []
 

--- a/problems/LOSCA/sub.i
+++ b/problems/LOSCA/sub.i
@@ -41,6 +41,11 @@ diri_temp=922
   nt_exp_form = false
   family = MONOMIAL
   order = CONSTANT
+  loop_precs = true
+  multi_app = loopApp
+  is_loopapp = true
+  inlet_boundaries = left
+
  [../]
 []
 

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -323,6 +323,7 @@ PrecursorAction::postAct(const std::string & var_name)
     params.set<std::vector<VariableName>>("variable") = varvec;
     params.set<std::vector<BoundaryName>>("boundary") =
         getParam<std::vector<BoundaryName>>("outlet_boundaries");
+    params.set<std::vector<OutputName>>("outputs") = {"none"};
 
     _problem->addPostprocessor("SideAverageValue", postproc_name, params);
   }
@@ -330,6 +331,7 @@ PrecursorAction::postAct(const std::string & var_name)
     std::string postproc_name = "Inlet_SideAverageValue_" + var_name + "_" + _object_suffix;
     InputParameters params = _factory.getValidParams("Receiver");
     params.set<MultiMooseEnum>("execute_on") = "timestep_begin";
+    params.set<std::vector<OutputName>>("outputs") = {"none"};
 
     _problem->addPostprocessor("Receiver", postproc_name, params);
   }

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -68,8 +68,7 @@ PrecursorAction::PrecursorAction(const InputParameters & params)
     _num_precursor_groups(getParam<unsigned int>("num_precursor_groups")),
     _var_name_base(getParam<std::string>("var_name_base")),
     _num_groups(getParam<unsigned int>("num_groups")),
-    _object_suffix(getParam<std::string>("object_suffix")),
-    _multi_app(getParam<MultiAppName>("multi_app"))
+    _object_suffix(getParam<std::string>("object_suffix"))
 {
   if (getParam<bool>("loop_precs"))
   {
@@ -320,7 +319,7 @@ PrecursorAction::act()
         // loop must be connected to the core problem.
         std::string postproc_name = "Outlet_SideAverageValue_"+var_name+"_"+_object_suffix;
         InputParameters params = _factory.getValidParams("SideAverageValue");
-        params.set<NonlinearVariableName>("variable") = var_name;
+        params.set<VariableName>("variable") = var_name;
         params.set<std::vector<BoundaryName>>("boundary") =
             getParam<std::vector<BoundaryName>>("outlet_boundaries");
         
@@ -335,7 +334,7 @@ PrecursorAction::act()
         {
             std::string transfer_name = "toloop_Transfer_" + var_name + "_"+_object_suffix;
             InputParameters params = _factory.getValidParams("MultiAppPostprocessorTransfer");
-            params.set<MultiAppName>("multi_app") = _multi_app;
+            params.set<MultiAppName>("multi_app") = getParam<MultiAppName>("multi_app");
             params.set<PostprocessorName>("from_postprocessor") = "Outlet_SideAverageValue_"+var_name+"_"+_object_suffix;
             params.set<PostprocessorName>("to_postprocessor") = "Inlet_SideAverageValue_"+var_name+"_"+_object_suffix;
             params.set<MooseEnum>("direction") = "to_multiapp";
@@ -345,7 +344,7 @@ PrecursorAction::act()
         {
             std::string transfer_name = "fromloop_Transfer_" + var_name + "_" + _object_suffix;
             InputParameters params = _factory.getValidParams("MultiAppPostprocessorTransfer");
-            params.set<MultiAppName>("multi_app") = _multi_app;
+            params.set<MultiAppName>("multi_app") = getParam<MultiAppName>("multi_app");
             params.set<PostprocessorName>("from_postprocessor") = "Outlet_SideAverageValue_"+var_name+"_"+_object_suffix;
             params.set<PostprocessorName>("to_postprocessor") = "Inlet_SideAverageValue_"+var_name+"_"+_object_suffix;
             params.set<MooseEnum>("direction") = "from_multiapp";

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -247,7 +247,7 @@ PrecursorAction::act()
       // INFLOW
       if (getParam<bool>("loop_precs"))
       {
-          // this SHOULD work for both constant and nonconstant flows as long as
+          // this will work for both constant and nonconstant flows as long as
           // nonconstant flows implemented in the Controls module by
           // setting values called uu, vv, ww.
           if (!getParam<bool>("constant_velocity_values"))
@@ -273,21 +273,6 @@ PrecursorAction::act()
           _problem->addBoundaryCondition("PostprocessorInflowBC", kernel_name, params);
       }
 
-      // fixed concentration input: no use at the moment so commented out
-      // {
-      //   // requires new BC: PostprocessorInflowBC
-      //   InputParameters params = _factory.getValidParams("InflowBC");
-      //   params.set<NonlinearVariableName>("variable") = var_name;
-      //   params.set<std::vector<BoundaryName> >("boundary") = getParam<std::vector<BoundaryName>
-      //   >("inlet_boundaries");
-      //   RealVectorValue vel = {getParam<Real>("u_def"), getParam<Real>("v_def"),
-      //   getParam<Real>("w_def")};
-      //   params.set<RealVectorValue>("velocity") = vel;
-      //   params.set<Real>("inlet_conc") = 1.;
-
-      //   std::string kernel_name = "InflowBC_" + var_name;
-      //   _problem->addBoundaryCondition("InflowBC", kernel_name, params);
-      // }
     }
 
     // Set up ICs

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -322,7 +322,7 @@ PrecursorAction::act()
         InputParameters params = _factory.getValidParams("SideAverageValue");
         params.set<NonlinearVariableName>("variable") = var_name;
         params.set<std::vector<BoundaryName>>("boundary") =
-            getParam<std::vector<BoundarName>>("outlet_boundaries");
+            getParam<std::vector<BoundaryName>>("outlet_boundaries");
         
         _problem->addPostprocessor("SideAverageValue", postproc_name, params);
         

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -193,6 +193,8 @@ MoltresApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   registerAction(PrecursorAction, "add_transfer");
   registerAction(PrecursorAction, "check_copy_nodal_vars");
   registerAction(PrecursorAction, "copy_nodal_vars");
+  addTaskDependency("add_bc", "add_postprocessor");
+  addTaskDependency("add_transfer", "add_postprocessor");
   registerAction(NtAction, "add_kernel");
   registerAction(NtAction, "add_bc");
   registerAction(NtAction, "add_variable");

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -193,8 +193,6 @@ MoltresApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   registerAction(PrecursorAction, "add_transfer");
   registerAction(PrecursorAction, "check_copy_nodal_vars");
   registerAction(PrecursorAction, "copy_nodal_vars");
-  addTaskDependency("add_bc", "add_postprocessor");
-  addTaskDependency("add_transfer", "add_postprocessor");
   registerAction(NtAction, "add_kernel");
   registerAction(NtAction, "add_bc");
   registerAction(NtAction, "add_variable");

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -185,10 +185,12 @@ MoltresApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
   syntax.registerActionSyntax("NtAction", "Nt");
 
   registerAction(PrecursorAction, "add_kernel");
+  registerAction(PrecursorAction, "add_postprocessor");
   registerAction(PrecursorAction, "add_bc");
   registerAction(PrecursorAction, "add_variable");
   registerAction(PrecursorAction, "add_ic");
   registerAction(PrecursorAction, "add_dg_kernel");
+  registerAction(PrecursorAction, "add_transfer");
   registerAction(PrecursorAction, "check_copy_nodal_vars");
   registerAction(PrecursorAction, "copy_nodal_vars");
   registerAction(NtAction, "add_kernel");


### PR DESCRIPTION
This PR extends the PrecursorAction. Now, if a multiapp is being used to model a salt loop, the postprocessors, transfers, and inflow boundary conditions needed to simulate precursor movement between core and loop can be automatically added with some simple syntax.

Looking in the problems/LOSCA case, you can see how easy it was to adapt the problem for circulating DNPs. The is_loopapp argument must be set to determine whether Transfer objects are set up, which only belong in the main app.

Attached is an image of precursor concentration in the salt loop in steady state.
![preccirc](https://user-images.githubusercontent.com/18088906/29892072-36037576-8d9b-11e7-959a-b2547c821d9d.png)
