### PR TITLE
Update MooseVariableInterface constructor call.

### DIFF
--- a/src/postprocessors/IntegralNewVariablePostprocessor.C
+++ b/src/postprocessors/IntegralNewVariablePostprocessor.C
@@ -16,7 +16,9 @@ IntegralNewVariablePostprocessor::IntegralNewVariablePostprocessor(
     const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
     ScalarTransportBase(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(this, false, "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u(coupledValue("variable")),
     _grad_u(coupledGradient("variable")),
     _u_dot(coupledDot("variable"))

--- a/src/postprocessors/IntegralOldVariablePostprocessor.C
+++ b/src/postprocessors/IntegralOldVariablePostprocessor.C
@@ -16,7 +16,9 @@ IntegralOldVariablePostprocessor::IntegralOldVariablePostprocessor(
     const InputParameters & parameters)
   : ElementIntegralPostprocessor(parameters),
     ScalarTransportBase(parameters),
-    MooseVariableInterface<Real>(this, false),
+    MooseVariableInterface<Real>(this, false, "variable",
+                                 Moose::VarKindType::VAR_ANY,
+                                 Moose::VarFieldType::VAR_FIELD_STANDARD),
     _u_old(coupledValueOld("variable")),
     _grad_u_old(coupledGradientOld("variable"))
 {


### PR DESCRIPTION
The `MooseVariableInterface` class constructor now accepts additional (defaulted) arguments in order to allow for additional runtime error checking that the variable in question comes from the appropriate system (Nonlinear vs. Aux) and is of the desired type (standard vs. SCALAR vs. vector).

Refs idaholab/moose#11192.
