### PR TITLE
SUPER easy fix for nonlinear external loop coupling

### DIFF
--- a/problems/LOSCA/auto_diff_rho.i
+++ b/problems/LOSCA/auto_diff_rho.i
@@ -21,18 +21,24 @@ diri_temp=922
   coord_type = RZ
 []
 
+[Nt]
+  var_name_base = group
+  vacuum_boundaries = 'fuel_bottoms fuel_tops moder_bottoms moder_tops outer_wall'
+  create_temperature_var = false
+  scaling = 1e-4
+  pre_blocks = 'fuel'
+[]
+
 [Variables]
   [./group1]
     order = FIRST
     family = LAGRANGE
     scaling = 1e4
-    initial_condition = 1
   [../]
   [./group2]
     order = FIRST
     family = LAGRANGE
     scaling = 1e4
-    initial_condition = 1
   [../]
   [./temp]
     scaling = 1e-4
@@ -59,62 +65,6 @@ diri_temp=922
 []
 
 [Kernels]
-  # Neutronics
-  [./time_group1]
-    type = NtTimeDerivative
-    variable = group1
-    group_number = 1
-  [../]
-  [./diff_group1]
-    type = GroupDiffusion
-    variable = group1
-    group_number = 1
-  [../]
-  [./sigma_r_group1]
-    type = SigmaR
-    variable = group1
-    group_number = 1
-  [../]
-  [./fission_source_group1]
-    type = CoupledFissionKernel
-    variable = group1
-    group_number = 1
-  [../]
-  [./delayed_group1]
-    type = DelayedNeutronSource
-    variable = group1
-  [../]
-  [./inscatter_group1]
-    type = InScatter
-    variable = group1
-    group_number = 1
-  [../]
-  [./diff_group2]
-    type = GroupDiffusion
-    variable = group2
-    group_number = 2
-  [../]
-  [./sigma_r_group2]
-    type = SigmaR
-    variable = group2
-    group_number = 2
-  [../]
-  [./time_group2]
-    type = NtTimeDerivative
-    variable = group2
-    group_number = 2
-  [../]
-  [./fission_source_group2]
-    type = CoupledFissionKernel
-    variable = group2
-    group_number = 2
-  [../]
-  [./inscatter_group2]
-    type = InScatter
-    variable = group2
-    group_number = 2
-  [../]
-
   # Temperature
   [./temp_time_derivative]
     type = MatINSTemperatureTimeDerivative

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -378,7 +378,7 @@ PrecursorAction::postAct(const std::string & var_name)
   {
     std::string postproc_name = "Inlet_SideAverageValue_" + var_name + "_" + _object_suffix;
     InputParameters params = _factory.getValidParams("Receiver");
-    params.set<ExecFlagEnum>("execute_on") = "timestep_begin";
+    params.set<ExecFlagEnum>("execute_on") = "nonlinear";
     params.set<std::vector<OutputName>>("outputs") = {"none"};
 
     _problem->addPostprocessor("Receiver", postproc_name, params);


### PR DESCRIPTION
Addresses #70 

For eigenvalue-type calculations, coupling to the external loop should be done on nonlinear iteration steps rather than timestep_begin. It *could* be on linear since this transport-type problem is in theory purely linear, but I feel that'd come with more software overhead in doing the transfers than we want. So, nonlinear updates make sense. I tested with the LOSCA walk-to-steady case, and it seemed to work great. Maybe we need a unit test for looping precursors though...