### PR TITLE
Update auto_diff_rho.i

### DIFF
--- a/problems/LOSCA/HXFailure/auto_diff_rho.i
+++ b/problems/LOSCA/HXFailure/auto_diff_rho.i
@@ -87,6 +87,8 @@ diri_temp=922
   [./delayed_group1]
     type = DelayedNeutronSource
     variable = group1
+    block = 'fuel'
+    group_number = 1
   [../]
   [./inscatter_group1]
     type = InScatter


### PR DESCRIPTION
"delayed_group1" kernel requires two additional pieces of information to run:
1) block = 'fuel'
2) group_number = 1