### PR TITLE
Remove dependence on AddVariableAction

### DIFF
--- a/include/actions/NtAction.h
+++ b/include/actions/NtAction.h
@@ -1,7 +1,7 @@
 #ifndef NTACTION_H
 #define NTACTION_H
 
-#include "AddVariableAction.h"
+#include "VariableNotAMooseObjectAction.h"
 
 /**
  * Add neutronics kernels and variables to MSR simulations automatically.
@@ -19,12 +19,12 @@
  * simulation. In addition, when using many flux variables, it adds the required variables to the
  * problem as well.
  */
-class NtAction : public AddVariableAction
+class NtAction : public VariableNotAMooseObjectAction
 {
 public:
   NtAction(const InputParameters & params);
 
-  virtual void act();
+  virtual void act() override;
 
 protected:
   /// number of precursor groups

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -1,7 +1,7 @@
 #ifndef PRECURSORACTION_H
 #define PRECURSORACTION_H
 
-#include "AddVariableAction.h"
+#include "VariableNotAMooseObjectAction.h"
 
 /**
  * This Action adds all required delayed neutron precursor variables and
@@ -16,7 +16,7 @@
  * or DGTemperatureAdvection. In order to vary to flow through a user-defined
  * function, use DGFunctionAdvection or DGFunctionTemperatureAdvection.
  */
-class PrecursorAction : public AddVariableAction
+class PrecursorAction : public VariableNotAMooseObjectAction
 {
 public:
   PrecursorAction(const InputParameters & params);

--- a/include/actions/VariableNotAMooseObjectAction.h
+++ b/include/actions/VariableNotAMooseObjectAction.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Action.h"
+
+class VariableNotAMooseObjectAction : public Action
+{
+public:
+  VariableNotAMooseObjectAction(const InputParameters & params);
+
+protected:
+  /**
+   * Get the block ids from the input parameters
+   * @return A set of block ids defined in the input
+   */
+  std::set<SubdomainID> getSubdomainIDs();
+
+  /**
+   * Add a variable
+   * @param var_name The variable name
+   */
+  void addVariable(const std::string & var_name);
+};
+
+template <>
+InputParameters validParams<VariableNotAMooseObjectAction>();

--- a/src/actions/NtAction.C
+++ b/src/actions/NtAction.C
@@ -27,7 +27,8 @@ template <>
 InputParameters
 validParams<NtAction>()
 {
-  InputParameters params = validParams<AddVariableAction>();
+  InputParameters params = validParams<VariableNotAMooseObjectAction>();
+
   params.addRequiredParam<unsigned int>("num_precursor_groups",
                                         "specifies the total number of precursors to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
@@ -71,7 +72,7 @@ validParams<NtAction>()
 }
 
 NtAction::NtAction(const InputParameters & params)
-  : AddVariableAction(params),
+  : VariableNotAMooseObjectAction(params),
     _num_precursor_groups(getParam<unsigned int>("num_precursor_groups")),
     _var_name_base(getParam<std::string>("var_name_base")),
     _num_groups(getParam<unsigned int>("num_groups"))
@@ -111,7 +112,9 @@ NtAction::act()
     //
 
     if (_current_task == "add_variable")
+    {
       addVariable(var_name);
+    }
 
     if (_current_task == "add_kernel")
     {

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -28,7 +28,7 @@ template <>
 InputParameters
 validParams<PrecursorAction>()
 {
-  InputParameters params = validParams<AddVariableAction>();
+  InputParameters params = validParams<VariableNotAMooseObjectAction>();
   params.addRequiredParam<unsigned int>("num_precursor_groups",
                                         "specifies the total number of precursors to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");
@@ -84,7 +84,7 @@ validParams<PrecursorAction>()
 }
 
 PrecursorAction::PrecursorAction(const InputParameters & params)
-  : AddVariableAction(params),
+  : VariableNotAMooseObjectAction(params),
     _num_precursor_groups(getParam<unsigned int>("num_precursor_groups")),
     _var_name_base(getParam<std::string>("var_name_base")),
     _num_groups(getParam<unsigned int>("num_groups")),

--- a/src/actions/VariableNotAMooseObjectAction.C
+++ b/src/actions/VariableNotAMooseObjectAction.C
@@ -1,0 +1,66 @@
+#include "VariableNotAMooseObjectAction.h"
+
+#include "AddVariableAction.h"
+#include "FEProblemBase.h"
+
+#include "libmesh/string_to_enum.h"
+#include "libmesh/fe_type.h"
+
+template <>
+InputParameters
+validParams<VariableNotAMooseObjectAction>()
+{
+  InputParameters params = validParams<Action>();
+
+  // Get MooseEnums for the possible order/family options for this variable
+  MooseEnum families(AddVariableAction::getNonlinearVariableFamilies());
+  MooseEnum orders(AddVariableAction::getNonlinearVariableOrders());
+
+  // add_variable parameters
+  params.addParam<MooseEnum>(
+      "family", families, "Specifies the family of FE shape functions to use for this variable");
+  params.addParam<MooseEnum>("order",
+                             orders,
+                             "Specifies the order of the FE shape function to use "
+                             "for this variable (additional orders not listed are "
+                             "allowed)");
+  params.addParam<Real>("scaling", 1.0, "Specifies a scaling factor to apply to this variable");
+  params.addParam<std::vector<SubdomainName>>("block", "The block id where this variable lives");
+  return params;
+}
+
+VariableNotAMooseObjectAction::VariableNotAMooseObjectAction(const InputParameters & params)
+  : Action(params)
+{
+}
+
+std::set<SubdomainID>
+VariableNotAMooseObjectAction::getSubdomainIDs()
+{
+  // Extract and return the block ids supplied in the input
+  std::set<SubdomainID> blocks;
+  std::vector<SubdomainName> block_param = getParam<std::vector<SubdomainName>>("block");
+  for (const auto & subdomain_name : block_param)
+  {
+    SubdomainID blk_id = _problem->mesh().getSubdomainID(subdomain_name);
+    blocks.insert(blk_id);
+  }
+  return blocks;
+}
+
+void
+VariableNotAMooseObjectAction::addVariable(const std::string & var_name)
+{
+  std::set<SubdomainID> blocks = getSubdomainIDs();
+  if (blocks.empty())
+    _problem->addVariable(var_name,
+                          FEType(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
+                                 Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family"))),
+                          getParam<Real>("scaling"));
+  else
+    _problem->addVariable(var_name,
+                          FEType(Utility::string_to_enum<Order>(getParam<MooseEnum>("order")),
+                                 Utility::string_to_enum<FEFamily>(getParam<MooseEnum>("family"))),
+                          getParam<Real>("scaling"),
+                          &blocks);
+}


### PR DESCRIPTION
In idaholab/moose#13769 AddVariableAction will become a
MooseObjectAction meaning it is really only designed for
adding variables. Actions that add the kitchen sink should
not inherit from AddVariableAction, and instead should inherit
from the arbitrarily general Action