### PR TITLE
extractSerpent2GCs.py fix

### DIFF
--- a/python/extractSerpent2GCs.py
+++ b/python/extractSerpent2GCs.py
@@ -69,19 +69,19 @@ def makePropertiesDir(
             if mat in item:
                 currentMat = mat
                 break
-        if not secBranch:
-            strData = coeList[currentMat].branches[item].universes[int(
-                uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
-            strData = strData[1:9]
-            if np.any(strData[-2:] != 0.0):
-                use8Groups = True
-        else:
+        if secBranch:
             for branch in secBranch:
                 strData = coeList[currentMat].branches[item, branch].universes[int(
                     uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
                 strData = strData[1:9]
                 if np.any(strData[-2:] != 0.0):
                     use8Groups = True
+        else:
+            strData = coeList[currentMat].branches[item].universes[int(
+                uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
+            strData = strData[1:9]
+            if np.any(strData[-2:] != 0.0):
+                use8Groups = True
 
     # Now loop through a second time
     branch2TempMapping.close()
@@ -100,28 +100,7 @@ def makePropertiesDir(
                 'Couldnt find a material corresponding to branch {}'.format(item))
 
         try:
-            if not secBranch:
-                for coefficient in goodStuff:
-                    with open(outdir + '/' + filebase + '_' + currentMat + '_' + coefficient.upper() + '.txt', 'a') as fh:
-                        if coefficient == 'lambda' or coefficient == 'BETA_EFF':
-                            strData = coeList[currentMat].branches[item].universes[int(
-                                uniMap[currentMat]), 0, 0].gc[goodMap[coefficient]]
-                            # some additional formatting is needed here
-                            strData = strData[1:9]
-
-                            # Cut off group 7 and 8 precursor params in 6
-                            # group calcs
-                            if not use8Groups:
-                                strData = strData[0:6]
-                        else:
-                            strData = coeList[currentMat].branches[item].universes[int(
-                                uniMap[currentMat]), 0, 0].infExp[goodMap[coefficient]]
-                        strData = ' '.join([str(dat) for dat in strData]) if isinstance(
-                            strData, np.ndarray) else strData
-                        fh.write(str(temp) + ' ' + strData)
-                        fh.write('\n')
-
-            else:
+            if secBranch:
                 for branch in secBranch:
                     for coefficient in goodStuff:
                         with open(outdir + '/' + filebase + '_' + currentMat + '_' + branch + '_' + coefficient.upper() + '.txt', 'a') as fh:
@@ -142,6 +121,27 @@ def makePropertiesDir(
                                 strData, np.ndarray) else strData
                             fh.write(str(temp) + ' ' + strData)
                             fh.write('\n')
+
+            else:
+                for coefficient in goodStuff:
+                    with open(outdir + '/' + filebase + '_' + currentMat + '_' + coefficient.upper() + '.txt', 'a') as fh:
+                        if coefficient == 'lambda' or coefficient == 'BETA_EFF':
+                            strData = coeList[currentMat].branches[item].universes[int(
+                                uniMap[currentMat]), 0, 0].gc[goodMap[coefficient]]
+                            # some additional formatting is needed here
+                            strData = strData[1:9]
+
+                            # Cut off group 7 and 8 precursor params in 6
+                            # group calcs
+                            if not use8Groups:
+                                strData = strData[0:6]
+                        else:
+                            strData = coeList[currentMat].branches[item].universes[int(
+                                uniMap[currentMat]), 0, 0].infExp[goodMap[coefficient]]
+                        strData = ' '.join([str(dat) for dat in strData]) if isinstance(
+                            strData, np.ndarray) else strData
+                        fh.write(str(temp) + ' ' + strData)
+                        fh.write('\n')
 
         except KeyError:
             print(secBranch)

--- a/python/extractSerpent2GCs.py
+++ b/python/extractSerpent2GCs.py
@@ -69,19 +69,19 @@ def makePropertiesDir(
             if mat in item:
                 currentMat = mat
                 break
-        if secBranch:
+        if not secBranch:
+            strData = coeList[currentMat].branches[item].universes[int(
+                uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
+            strData = strData[1:9]
+            if np.any(strData[-2:] != 0.0):
+                use8Groups = True
+        else:
             for branch in secBranch:
                 strData = coeList[currentMat].branches[item, branch].universes[int(
                     uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
                 strData = strData[1:9]
                 if np.any(strData[-2:] != 0.0):
                     use8Groups = True
-        else:
-            strData = coeList[currentMat].branches[item, branch].universes[int(
-                uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
-            strData = strData[1:9]
-            if np.any(strData[-2:] != 0.0):
-                use8Groups = True
 
     # Now loop through a second time
     branch2TempMapping.close()

--- a/python/extractSerpent2GCs.py
+++ b/python/extractSerpent2GCs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# This script extracts group constants from Serpent 2. It should be able to do all of the work, no
-# need to specify how many energy groups, or anything like that. Also, this could be imported into
+# This script extracts group constants from Serpent 2. It should be
+# able to do all of the work, no need to specify how many energy
+# groups, or anything like that. Also, this could be imported into
 # other python scripts if needed, maybe for parametric studies.
 import os
 import numpy as np
@@ -71,8 +72,9 @@ def makePropertiesDir(
                 break
         if secBranch:
             for branch in secBranch:
-                strData = coeList[currentMat].branches[item, branch].universes[int(
-                    uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
+                strData = coeList[currentMat].branches[
+                    item, branch].universes[int(
+                        uniMap[currentMat]), 0, 0].gc[goodMap['BETA_EFF']]
                 strData = strData[1:9]
                 if np.any(strData[-2:] != 0.0):
                     use8Groups = True
@@ -97,16 +99,22 @@ def makePropertiesDir(
         else:
             print('Considered materials: {}'.format(inmats))
             raise Exception(
-                'Couldnt find a material corresponding to branch {}'.format(item))
+                'Couldnt find a material corresponding to branch {}'.format(
+                    item))
 
         try:
             if secBranch:
                 for branch in secBranch:
                     for coefficient in goodStuff:
-                        with open(outdir + '/' + filebase + '_' + currentMat + '_' + branch + '_' + coefficient.upper() + '.txt', 'a') as fh:
-                            if coefficient == 'lambda' or coefficient == 'BETA_EFF':
-                                strData = coeList[currentMat].branches[item, branch].universes[int(
-                                    uniMap[currentMat]), 0, 0].gc[goodMap[coefficient]]
+                        with open(outdir + '/' + filebase + '_' + currentMat +
+                                  '_' + branch + '_' + coefficient.upper() +
+                                  '.txt', 'a') as fh:
+                            if coefficient == 'lambda' or \
+                                    coefficient == 'BETA_EFF':
+                                strData = coeList[currentMat].branches[
+                                    item, branch].universes[int(
+                                        uniMap[currentMat]), 0, 0].gc[
+                                            goodMap[coefficient]]
                                 # some additional formatting is needed here
                                 strData = strData[1:9]
 
@@ -115,19 +123,26 @@ def makePropertiesDir(
                                 if not use8Groups:
                                     strData = strData[0:6]
                             else:
-                                strData = coeList[currentMat].branches[item, branch].universes[int(
-                                    uniMap[currentMat]), 0, 0].infExp[goodMap[coefficient]]
-                            strData = ' '.join([str(dat) for dat in strData]) if isinstance(
-                                strData, np.ndarray) else strData
+                                strData = coeList[currentMat].branches[
+                                    item, branch].universes[int(
+                                        uniMap[currentMat]), 0, 0].infExp[
+                                            goodMap[coefficient]]
+                            strData = ' '.join(
+                                [str(dat) for dat in strData]) if isinstance(
+                                    strData, np.ndarray) else strData
                             fh.write(str(temp) + ' ' + strData)
                             fh.write('\n')
 
             else:
                 for coefficient in goodStuff:
-                    with open(outdir + '/' + filebase + '_' + currentMat + '_' + coefficient.upper() + '.txt', 'a') as fh:
-                        if coefficient == 'lambda' or coefficient == 'BETA_EFF':
-                            strData = coeList[currentMat].branches[item].universes[int(
-                                uniMap[currentMat]), 0, 0].gc[goodMap[coefficient]]
+                    with open(outdir + '/' + filebase + '_' + currentMat +
+                              '_' + coefficient.upper() + '.txt', 'a') as fh:
+                        if coefficient == 'lambda' or \
+                                coefficient == 'BETA_EFF':
+                            strData = coeList[currentMat].branches[
+                                item].universes[int(
+                                    uniMap[currentMat]), 0, 0].gc[
+                                        goodMap[coefficient]]
                             # some additional formatting is needed here
                             strData = strData[1:9]
 
@@ -136,10 +151,13 @@ def makePropertiesDir(
                             if not use8Groups:
                                 strData = strData[0:6]
                         else:
-                            strData = coeList[currentMat].branches[item].universes[int(
-                                uniMap[currentMat]), 0, 0].infExp[goodMap[coefficient]]
-                        strData = ' '.join([str(dat) for dat in strData]) if isinstance(
-                            strData, np.ndarray) else strData
+                            strData = coeList[currentMat].branches[
+                                item].universes[int(
+                                    uniMap[currentMat]), 0, 0].infExp[
+                                        goodMap[coefficient]]
+                        strData = ' '.join(
+                            [str(dat) for dat in strData]) if isinstance(
+                                strData, np.ndarray) else strData
                         fh.write(str(temp) + ' ' + strData)
                         fh.write('\n')
 
@@ -151,7 +169,8 @@ if __name__ == '__main__':
 
     # make it act like a nice little terminal program
     parser = argparse.ArgumentParser(
-        description='Extracts Serpent 2 group constants, and puts them in a directory suitable for moltres.')
+        description='Extracts Serpent 2 group constants, \
+            and puts them in a directory suitable for moltres.')
     parser.add_argument('outDir', metavar='o', type=str, nargs=1,
                         help='name of directory to write properties to.')
     parser.add_argument('fileBase', metavar='f', type=str,


### PR DESCRIPTION
The latest change by @gridley introduced automatic checking for the number of DNP groups (6 or 8 depending on the nuclear data library) to remove extra zeros if there are only 6 groups.

The script works for cases with secondary branches (resulting from Serpent automated burnup sequences or varying control rod positions)

The script fails for cases without secondary branches as the "branch" variable is null. The fix simply involves removing the "branch" variable call for these cases in the DNP group check.

The if-else code portions are also swapped to maintain consistency with the original code.