### PR TITLE
Add prop_names and prop_values to material objects

### DIFF
--- a/tutorial/PinCell/pin_cell.i
+++ b/tutorial/PinCell/pin_cell.i
@@ -33,6 +33,8 @@ global_temperature=600
     material_key = 'F'
     interp_type = 'NONE'
     temperature = 600
+    prop_names = ''
+    prop_values = ''
   [../]
   [./C]
     type = MoltresJsonMaterial
@@ -40,6 +42,8 @@ global_temperature=600
     material_key = 'C'
     interp_type = 'NONE'
     temperature = 600
+    prop_names = ''
+    prop_values = ''
   [../]
   [./W]
     type = MoltresJsonMaterial
@@ -47,6 +51,8 @@ global_temperature=600
     material_key = 'W'
     interp_type = 'NONE'
     temperature = 600
+    prop_names = ''
+    prop_values = ''
   [../]
 []
 


### PR DESCRIPTION
This PR fixes a minor issue @gwenchee found in the pin cell tutorial. It seems that GenericConstantMaterial in MOOSE got an update at some point which made "prop_names" a required parameter. 

Thus I've added "prop_names = ' ' " and "prop_values = ' ' " to the MoltresJsonMaterial blocks.