### PR TITLE
Update broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@
     [Integrator Workflow ](http://en.wikipedia.org/wiki/Integrator_workflow).
 
 -   Use a branching workflow similar to the one described
-    in the [progit gitbook](http://progit.org/book/ch3-4.html).
+    in the [progit gitbook](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows).
 
 -   Keep your own "master" and "devel" branches in sync with the
     main repository's "master" and "devel" branches. Specifically,
@@ -50,7 +50,7 @@
 
 -   Look over the code.
 
--   Check that it meets the [MOOSE style guidelines](http://mooseframework.org/wiki/CodeStandards/).
+-   Check that it meets the [MOOSE style guidelines](https://www.mooseframework.org/framework_development/code_standards.html).
 
 -   Make inline review comments concerning improvements.
 


### PR DESCRIPTION
All links except for the style guide near the bottom of the document are now fixed. I do not know how to locate the resource that was located at the style guide hyperlink, so issue #128 cannot be closed until this resource is located or the document is edited to remove this hyperlink