### PR TITLE
Update to gtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,31 @@ include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 ################################## MODULES ####################################
-ALL_MODULES := no
-PHASE_FIELD := yes
-NAVIER_STOKES := yes
+# To use certain physics included with MOOSE, set variables below to
+# # yes as needed.  Or set ALL_MODULES to yes to turn on everything (overrides
+# # other set variables).
+
+ALL_MODULES                 := no
+
+CHEMICAL_REACTIONS          := no
+CONTACT                     := no
+EXTERNAL_PETSC_SOLVER       := no
+FLUID_PROPERTIES            := no
+FUNCTIONAL_EXPANSION_TOOLS  := no
+GEOCHEMISTRY                := no
+HEAT_CONDUCTION             := no
+LEVEL_SET                   := no
+MISC                        := no
+NAVIER_STOKES               := yes
+PHASE_FIELD                 := yes
+POROUS_FLOW                 := no
+RAY_TRACING                 := no
+RDG                         := no
+RICHARDS                    := no
+STOCHASTIC_TOOLS            := no
+TENSOR_MECHANICS            := no
+XFEM                        := no
+
 include $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ include $(FRAMEWORK_DIR)/moose.mk
 
 ################################## MODULES ####################################
 # To use certain physics included with MOOSE, set variables below to
-# # yes as needed.  Or set ALL_MODULES to yes to turn on everything (overrides
-# # other set variables).
+# yes as needed.  Or set ALL_MODULES to yes to turn on everything (overrides
+# other set variables).
 
 ALL_MODULES                 := no
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -2,31 +2,50 @@
 ################### MOOSE Application Standard Makefile #######################
 ###############################################################################
 #
+# Required Environment variables (one of the following)
+# PACKAGES_DIR  - Location of the MOOSE redistributable package
+#
 # Optional Environment variables
-# MOOSE_DIR        - Root directory of the MOOSE project
-# HERD_TRUNK_DIR   - Location of the HERD repository
-# FRAMEWORK_DIR    - Location of the MOOSE framework
+# MOOSE_DIR     - Root directory of the MOOSE project
+# FRAMEWORK_DIR - Location of the MOOSE framework
 #
 ###############################################################################
-MOOSE_DIR          ?= $(shell dirname `pwd`)/../moose
+# Use the MOOSE submodule if it exists and MOOSE_DIR is not set
+MOOSE_SUBMODULE    := $(CURDIR)/../moose
+ifneq ($(wildcard $(MOOSE_SUBMODULE)/framework/Makefile),)
+  MOOSE_DIR        ?= $(MOOSE_SUBMODULE)
+else
+  MOOSE_DIR        ?= $(shell dirname `pwd`)/../moose
+endif
 FRAMEWORK_DIR      ?= $(MOOSE_DIR)/framework
 ###############################################################################
-CURRENT_DIR        := $(shell pwd)
 
 # framework
 include $(FRAMEWORK_DIR)/build.mk
 include $(FRAMEWORK_DIR)/moose.mk
 
 ################################## MODULES ####################################
-ALL_MODULES       := no
-PHASE_FIELD       := yes
+# set desired physics modules equal to 'yes' to enable them
+CHEMICAL_REACTIONS        := no
+CONTACT                   := no
+FLUID_PROPERTIES          := no
+HEAT_CONDUCTION           := no
+MISC                      := no
+NAVIER_STOKES             := yes
+PHASE_FIELD               := yes
+RDG                       := no
+RICHARDS                  := no
+STOCHASTIC_TOOLS          := no
+TENSOR_MECHANICS          := no
+XFEM                      := no
+POROUS_FLOW               := no
+LEVEL_SET                 := no
 include           $(MOOSE_DIR)/modules/modules.mk
 ###############################################################################
 
-# Extra stuff for CPPUNIT
-CPPUNIT_DIR 		?= $(PACKAGES_DIR)/cppunit
-ADDITIONAL_INCLUDES 	:= -I$(CPPUNIT_DIR)/include
-ADDITIONAL_LIBS 	:= -L$(CPPUNIT_DIR)/lib -lcppunit
+# Extra stuff for GTEST
+ADDITIONAL_INCLUDES := -I$(FRAMEWORK_DIR)/contrib/gtest
+ADDITIONAL_LIBS     := $(FRAMEWORK_DIR)/contrib/gtest/libgtest.la
 
 # Use the SQUIRREL submodule if it exists and SQUIRREL_DIR is not set
 SQUIRREL_SUBMODULE    := $(CURDIR)/../squirrel
@@ -42,6 +61,7 @@ APPLICATION_NAME   := squirrel
 include            $(FRAMEWORK_DIR)/app.mk
 
 # dep apps
+CURRENT_DIR        := $(shell pwd)
 APPLICATION_DIR    := $(CURRENT_DIR)/..
 APPLICATION_NAME   := moltres
 include            $(FRAMEWORK_DIR)/app.mk
@@ -49,6 +69,7 @@ include            $(FRAMEWORK_DIR)/app.mk
 APPLICATION_DIR    := $(CURRENT_DIR)
 APPLICATION_NAME   := moltres-unit
 BUILD_EXEC         := yes
+
 DEP_APPS    ?= $(shell $(FRAMEWORK_DIR)/scripts/find_dep_apps.py $(APPLICATION_NAME))
 include $(FRAMEWORK_DIR)/app.mk
 

--- a/unit/src/main.C
+++ b/unit/src/main.C
@@ -1,4 +1,13 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
 
+#include "MoltresApp.h"
 #include "gtest/gtest.h"
 
 // Moose includes
@@ -7,7 +16,6 @@
 
 #include "Factory.h"
 #include "AppFactory.h"
-#include "MoltresApp.h"
 
 #include <fstream>
 #include <string>

--- a/unit/src/main.C
+++ b/unit/src/main.C
@@ -1,9 +1,5 @@
 
-// CPPUnit includes
-#include "cppunit/XmlOutputter.h"
-#include "cppunit/CompilerOutputter.h"
-#include "cppunit/ui/text/TestRunner.h"
-#include "cppunit/extensions/TestFactoryRegistry.h"
+#include "gtest/gtest.h"
 
 // Moose includes
 #include "Moose.h"
@@ -16,40 +12,17 @@
 #include <fstream>
 #include <string>
 
-PerfLog Moose::perf_log("CppUnit");
+PerfLog Moose::perf_log("gtest");
 
-int
+GTEST_API_ int
 main(int argc, char ** argv)
 {
+  // gtest removes (only) its args from argc and argv - so this must be before moose init
+  testing::InitGoogleTest(&argc, argv);
+
   MooseInit init(argc, argv);
-
   registerApp(MoltresApp);
+  Moose::_throw_on_error = true;
 
-  CppUnit::Test * suite = CppUnit::TestFactoryRegistry::getRegistry().makeTest();
-
-  CppUnit::TextTestRunner runner;
-  runner.addTest(suite);
-  std::ofstream out;
-
-  // If you run with --xml, output will be sent to an xml file instead of the screen
-  if (argc == 2 && std::string(argv[1]) == std::string("--xml"))
-  {
-    runner.setOutputter(new CppUnit::XmlOutputter(&runner.result(), out));
-    out.open("test_results.xml");
-  }
-
-  else
-  {
-    // Note: upon calling setOutputter, any previous outputter is
-    // destroyed. The TextTestRunner assumes ownership of the outputter, so you
-    // don't have to worry about deleting it.
-    runner.setOutputter(new CppUnit::CompilerOutputter(&runner.result(), Moose::err));
-  }
-
-  bool wasSucessful = runner.run(/*testPath=*/"",
-                                 /*doWait=*/false,
-                                 /*doPrintResult=*/true,
-                                 /*doPrintProgress=*/false);
-
-  return wasSucessful ? 0 : 1;
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Closes #153 

This PR replaces cppunit and all associated code with gtest to bring Moltres in line with current standards for moose apps. I referred to equivalent files in [StorkApp](https://github.com/idaholab/moose/tree/next/stork) template in moose.

I also updated the Moltres Makefile to include the full list of physics modules available on moose.