### PR TITLE
Update deprecated code

### DIFF
--- a/problems/012017_temperature_to_dg/Input.i
+++ b/problems/012017_temperature_to_dg/Input.i
@@ -53,7 +53,7 @@ sigma_val=6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/012017_temperature_to_dg/test_mat_props.i
+++ b/problems/012017_temperature_to_dg/test_mat_props.i
@@ -59,7 +59,7 @@ sigma_val=6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/020617_mod_heat_source_one_minus_beta_fission/Input.i
+++ b/problems/020617_mod_heat_source_one_minus_beta_fission/Input.i
@@ -60,7 +60,7 @@ sigma_val=6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/020617_mod_heat_source_one_minus_beta_fission/Input_PJFNK.i
+++ b/problems/020617_mod_heat_source_one_minus_beta_fission/Input_PJFNK.i
@@ -60,7 +60,7 @@ sigma_val=6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/CG_temp.i
+++ b/problems/021417_MSRE_materials/CG_temp.i
@@ -59,7 +59,7 @@ global_temperature=temp
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/Input.i
+++ b/problems/021417_MSRE_materials/Input.i
@@ -61,7 +61,7 @@ sigma_val=6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/mini_msre_cg_temp.i
+++ b/problems/021417_MSRE_materials/mini_msre_cg_temp.i
@@ -59,7 +59,7 @@ global_temperature=temp
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale-PJFNK.i
+++ b/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale-PJFNK.i
@@ -106,7 +106,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale-mod-heat-PJFNK.i
+++ b/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale-mod-heat-PJFNK.i
@@ -113,7 +113,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale.i
+++ b/problems/021417_MSRE_materials/transient-nts-cg-temp-one-channel-two-mat-scale.i
@@ -106,7 +106,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/transient-nts-cg-temp-two-grp-b1-two-mat.i
+++ b/problems/021417_MSRE_materials/transient-nts-cg-temp-two-grp-b1-two-mat.i
@@ -99,7 +99,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/021417_MSRE_materials/transient-nts-cg-temp-two-grp-scale-two-mat-inverted-file-msh.i
+++ b/problems/021417_MSRE_materials/transient-nts-cg-temp-two-grp-scale-two-mat-inverted-file-msh.i
@@ -103,7 +103,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/2d_axi_function_cross_sections.i
@@ -141,7 +141,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
@@ -150,7 +150,7 @@ offset=2.5
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_direct.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_direct.i
@@ -133,7 +133,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_restart.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho_restart.i
@@ -135,7 +135,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin.i
@@ -133,7 +133,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive.i
@@ -132,7 +132,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive_PJFNK.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_single_pin_adaptive_PJFNK.i
@@ -132,7 +132,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function.i
@@ -134,7 +134,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function_moderator_heating.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_single_pin_velocity_function_moderator_heating.i
@@ -141,7 +141,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
@@ -142,7 +142,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_control.i
@@ -144,7 +144,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_monotone_interp.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho_monotone_interp.i
@@ -132,7 +132,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/060717_dimension_testing/one_group.i
+++ b/problems/060717_dimension_testing/one_group.i
@@ -95,7 +95,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]
@@ -127,7 +127,7 @@ diri_temp=922
   # [./temp_diffusion_outlet]
   #   boundary = 'fuel_tops'
   #   type = DiffusiveFluxBC
-  #   D_name = 'k'
+  #   diffusivity = 'k'
   #   variable = temp
   # [../]
 []

--- a/problems/060717_dimension_testing/test_case.i
+++ b/problems/060717_dimension_testing/test_case.i
@@ -69,7 +69,7 @@ diri_temp=1
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/072017_dg_temperature/auto_diff_rho.i
+++ b/problems/072017_dg_temperature/auto_diff_rho.i
@@ -143,7 +143,7 @@ sigma_val=.6
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]
@@ -187,7 +187,7 @@ sigma_val=.6
     variable = temp
     sigma = ${sigma_val}
     epsilon = -1
-    D_name = 'k'
+    diffusivity = 'k'
     postprocessor = coreEndTemp
     offset = -50
   [../]

--- a/problems/2017_annals_pub_msre_compare/2group.i
+++ b/problems/2017_annals_pub_msre_compare/2group.i
@@ -84,7 +84,7 @@ H=162.56
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/2017_annals_pub_msre_compare/4group.i
+++ b/problems/2017_annals_pub_msre_compare/4group.i
@@ -84,7 +84,7 @@ H=162.56
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
+++ b/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
@@ -84,7 +84,7 @@ H=162.56
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/LOFA/auto_diff_rho.i
+++ b/problems/LOFA/auto_diff_rho.i
@@ -145,7 +145,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/LOFA/steady/auto_diff_rho.i
+++ b/problems/LOFA/steady/auto_diff_rho.i
@@ -138,7 +138,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/LOSCA/HXFailure/auto_diff_rho.i
+++ b/problems/LOSCA/HXFailure/auto_diff_rho.i
@@ -141,7 +141,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/LOSCA/HXFailure/sub.i
+++ b/problems/LOSCA/HXFailure/sub.i
@@ -67,7 +67,7 @@ diri_temp=922
   # [../]
   # [./temp_diffusion]
   #   type = MatDiffusion
-  #   D_name = 'k'
+  #   diffusivity = 'k'
   #   variable = temp
   # [../]
   # [./temp_advection_fuel]

--- a/problems/LOSCA/auto_diff_rho.i
+++ b/problems/LOSCA/auto_diff_rho.i
@@ -85,7 +85,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/LOSCA/sub.i
+++ b/problems/LOSCA/sub.i
@@ -69,7 +69,7 @@ diri_temp=922
   # [../]
   # [./temp_diffusion]
   #   type = MatDiffusion
-  #   D_name = 'k'
+  #   diffusivity = 'k'
   #   variable = temp
   # [../]
   # [./temp_advection_fuel]

--- a/problems/advection_diffusion_reaction.i
+++ b/problems/advection_diffusion_reaction.i
@@ -32,7 +32,7 @@ velocity=1
   [./diffusion]
     type = MatDiffusion
     variable = u
-    D_name = 'mu'
+    diffusivity = 'mu'
   [../]
   # [./time]
   #   type = TimeDerivative

--- a/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
+++ b/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
@@ -140,7 +140,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/picard/auto_diff_rho.i
+++ b/problems/picard/auto_diff_rho.i
@@ -137,7 +137,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/picard/temp.i
+++ b/problems/picard/temp.i
@@ -87,7 +87,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/picard/temp_no_pres.i
+++ b/problems/picard/temp_no_pres.i
@@ -57,7 +57,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/picard/tmp_nts.i
+++ b/problems/picard/tmp_nts.i
@@ -116,7 +116,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/3d_steady_state/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/3d_steady_state/3d_auto_diff_rho.i
@@ -146,7 +146,7 @@ offset=2.5
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/LOSCA/HXFail/auto_diff_rho.i
+++ b/problems/publication_level_cases/LOSCA/HXFail/auto_diff_rho.i
@@ -135,7 +135,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/LOSCA/HXFail/sub.i
+++ b/problems/publication_level_cases/LOSCA/HXFail/sub.i
@@ -63,7 +63,7 @@ diri_temp=922
   # [../]
   # [./temp_diffusion]
   #   type = MatDiffusion
-  #   D_name = 'k'
+  #   diffusivity = 'k'
   #   variable = temp
   # [../]
   # [./temp_advection_fuel]

--- a/problems/publication_level_cases/LOSCA/auto_diff_rho.i
+++ b/problems/publication_level_cases/LOSCA/auto_diff_rho.i
@@ -131,7 +131,7 @@ diri_temp=922
   # [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/LOSCA/sub.i
+++ b/problems/publication_level_cases/LOSCA/sub.i
@@ -64,7 +64,7 @@ diri_temp=922
   # [../]
   # [./temp_diffusion]
   #   type = MatDiffusion
-  #   D_name = 'k'
+  #   diffusivity = 'k'
   #   variable = temp
   # [../]
   # [./temp_advection_fuel]

--- a/problems/publication_level_cases/dilute_absorber_controlled_by_peak_power_density/in.i
+++ b/problems/publication_level_cases/dilute_absorber_controlled_by_peak_power_density/in.i
@@ -144,7 +144,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/gamma_heating_3d_ss/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/gamma_heating_3d_ss/3d_auto_diff_rho.i
@@ -146,7 +146,7 @@ offset=2.5
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/transient_single_channel_blockage/3d_auto_diff_rho.i
+++ b/problems/publication_level_cases/transient_single_channel_blockage/3d_auto_diff_rho.i
@@ -159,7 +159,7 @@ offset=2.5
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/transient_single_channel_blockage/3d_ss.i
+++ b/problems/publication_level_cases/transient_single_channel_blockage/3d_ss.i
@@ -144,7 +144,7 @@ offset=2.5
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/publication_level_cases/twod_control_rod_yank/rodded.i
+++ b/problems/publication_level_cases/twod_control_rod_yank/rodded.i
@@ -77,7 +77,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/rodMatchSerpentWorth/adjustAbsorb/rodded.i
+++ b/problems/rodMatchSerpentWorth/adjustAbsorb/rodded.i
@@ -70,7 +70,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/rodMatchSerpentWorth/rodded.i
+++ b/problems/rodMatchSerpentWorth/rodded.i
@@ -70,7 +70,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/rodded2D/rodded.i
+++ b/problems/rodded2D/rodded.i
@@ -77,7 +77,7 @@ diri_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/problems/single_msre_channel_velocity_and_heat/heat-only-single-channel-msre-dimensions.i
+++ b/problems/single_msre_channel_velocity_and_heat/heat-only-single-channel-msre-dimensions.i
@@ -55,7 +55,7 @@ length = 162.56
   [../]
   [./temp_mod_transport]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
     block = 'moderator'
   [../]

--- a/problems/single_msre_channel_velocity_and_heat/single-channel-msre-dimensions-fluid-heat.i
+++ b/problems/single_msre_channel_velocity_and_heat/single-channel-msre-dimensions-fluid-heat.i
@@ -96,7 +96,7 @@ length = 162.56
   [../]
   [./temp_mod_transport]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
     block = 'moderator'
   [../]

--- a/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-channel-msre-dimensions.i
+++ b/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-channel-msre-dimensions.i
@@ -145,7 +145,7 @@ nt_scale=1e13
   [../]
   [./temp_mod_transport]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
     block = 'moderator'
   [../]

--- a/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-unit-cell.i
+++ b/problems/single_msre_channel_velocity_heat_nts/heat-nts-single-unit-cell.i
@@ -145,7 +145,7 @@ nt_scale=1e13
   [../]
   [./temp_mod_transport]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
     block = 'moderator'
   [../]

--- a/problems/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
+++ b/problems/single_msre_channel_velocity_heat_nts/unit-cell-heat-and-nts.i
@@ -153,7 +153,7 @@ nt_scale=1e13
   [../]
   [./temp_mod_transport]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
     # block = 'moderator'
   [../]

--- a/problems/subdomain_bounding_box.i
+++ b/problems/subdomain_bounding_box.i
@@ -25,7 +25,7 @@
   [./diff]
     type = MatDiffusion
     variable = u
-    D_name = 'k'
+    diffusivity = 'k'
     block = '0 1'
   [../]
   [./time]

--- a/src/actions/VariableNotAMooseObjectAction.C
+++ b/src/actions/VariableNotAMooseObjectAction.C
@@ -6,8 +6,6 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/fe_type.h"
 
-#include <iostream>
-
 template <>
 InputParameters
 validParams<VariableNotAMooseObjectAction>()

--- a/tests/nts/gen-mesh-one-material.i
+++ b/tests/nts/gen-mesh-one-material.i
@@ -90,7 +90,7 @@
   [./temp_cond]
     type = MatDiffusion
     variable = temp
-    D_name = 'k'
+    diffusivity = 'k'
     save_in = 'diffus_resid tot_resid'
   [../]
   # [./temp_cond]

--- a/tests/temp/temp.i
+++ b/tests/temp/temp.i
@@ -33,7 +33,7 @@ ini_temp=922
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_advection_fuel]

--- a/tests/twod_axi_coupled/auto_diff_rho.i
+++ b/tests/twod_axi_coupled/auto_diff_rho.i
@@ -139,7 +139,7 @@ nt_scale=1e13
   [../]
   [./temp_diffusion]
     type = MatDiffusion
-    D_name = 'k'
+    diffusivity = 'k'
     variable = temp
   [../]
   [./temp_source_fuel]


### PR DESCRIPTION
Fixes #150.

Running ```./run_tests -j4 --error-deprecated``` yields the following output:

```bash
pre.pre_loop_ins ................................................................................ [HEAVY] SKIP
pre.pre_loop .................................................................................... [HEAVY] SKIP
twod_axi_coupled.coupled ........................................................................ [HEAVY] SKIP
pre.pre ................................................................................................... OK
temp.temp ................................................................................................. OK
decay_heat.decay_heat ..................................................................................... OK
laminar_flow.boussinesqSquare ............................................................................. OK
bcs.coupled_bc ............................................................................................ OK
kernels.scalar_advection_art_diff ......................................................................... OK
postprocessors.side_weighted_integral ..................................................................... OK
nts.nts ................................................................................................... OK
problems/2017_annals_pub_msre_compare.4group ..................................................... SYNTAX PASS
postprocessors.side_weighted_integral_RZ .................................................................. OK
problems/2017_annals_pub_msre_compare.4group_eigen ............................................... SYNTAX PASS
problems/2017_annals_pub_msre_compare.2group ..................................................... SYNTAX PASS
problems/2017_annals_pub_msre_compare.2group_eigen ............................................... SYNTAX PASS
nts.nts_no_action ......................................................................................... OK
diracHX.dirachx ........................................................................................... OK
problems/2017_annals_pub_msre_compare.auto_diff_rho .............................................. SYNTAX PASS
problems/033117_nts_temp_pre_parsed_mat.syntax ....................................................... RUNNING
problems/033117_nts_temp_pre_parsed_mat.syntax ........................................ [FINISHED] SYNTAX PASS
--------------------------------------------------------------------------------------------------------------
Ran 17 tests in 131.0 seconds.
17 passed, 3 skipped, 0 pending, 0 failed

```

Some of the files where I changed `D_name` by `diffusivity` are not included in the tests, but I updated them anyway to be consistent.