### PR TITLE
Remove unused postprocessor parameter

### DIFF
--- a/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/auto_diff_rho.i
@@ -207,7 +207,6 @@ diri_temp=922
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -225,7 +224,6 @@ diri_temp=922
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]

--- a/problems/072017_dg_temperature/auto_diff_rho.i
+++ b/problems/072017_dg_temperature/auto_diff_rho.i
@@ -244,7 +244,6 @@ sigma_val=.6
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -262,7 +261,6 @@ sigma_val=.6
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]

--- a/problems/2017_annals_pub_msre_compare/2group.i
+++ b/problems/2017_annals_pub_msre_compare/2group.i
@@ -151,7 +151,6 @@ H=162.56
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -169,7 +168,6 @@ H=162.56
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]

--- a/problems/2017_annals_pub_msre_compare/4group.i
+++ b/problems/2017_annals_pub_msre_compare/4group.i
@@ -151,7 +151,6 @@ H=162.56
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -169,7 +168,6 @@ H=162.56
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]

--- a/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
+++ b/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
@@ -151,7 +151,6 @@ H=162.56
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -169,7 +168,6 @@ H=162.56
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]

--- a/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
+++ b/problems/constant_inlet_outlet_temp_no_heat_flux_at_walls/auto_diff_rho.i
@@ -212,7 +212,6 @@ diri_temp=922
     block = 'fuel'
     prop_names = 'k cp'
     prop_values = '.0553 1967' # Robertson MSRE technical report @ 922 K
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_fuel]
@@ -230,7 +229,6 @@ diri_temp=922
     prop_names = 'k cp'
     prop_values = '.312 1760' # Cammi 2011 at 908 K
     block = 'moder'
-    peak_power_density = peak_power_density
     controller_gain = 0
   [../]
   [./rho_moder]


### PR DESCRIPTION
The postprocessor "peak_power_density" does not really exist, but with the current PostprocessorInterface, it uses the default value even though you provided a name. With the changes in https://github.com/idaholab/moose/pull/17527, the error is now caught. The failure is here: https://civet.inl.gov/job/720393/

Only two of these inputs are tested, the rest are not. So, this may require a little more checking...