### PR TITLE
Replace deprecated code involving "include guards" and "validParams"

### DIFF
--- a/include/actions/NtAction.h
+++ b/include/actions/NtAction.h
@@ -25,9 +25,9 @@ public:
 
   static InputParameters validParams();
 
-protected:
-  void act() override;
+  virtual void act() override;
 
+protected:
   /// number of precursor groups
   unsigned int _num_precursor_groups;
 

--- a/include/actions/NtAction.h
+++ b/include/actions/NtAction.h
@@ -1,5 +1,4 @@
-#ifndef NTACTION_H
-#define NTACTION_H
+#pragma once
 
 #include "VariableNotAMooseObjectAction.h"
 
@@ -24,9 +23,11 @@ class NtAction : public VariableNotAMooseObjectAction
 public:
   NtAction(const InputParameters & params);
 
-  virtual void act() override;
+  static InputParameters validParams();
 
 protected:
+  void act() override;
+
   /// number of precursor groups
   unsigned int _num_precursor_groups;
 
@@ -36,8 +37,3 @@ protected:
   /// number of energy groups
   unsigned int _num_groups;
 };
-
-template <>
-InputParameters validParams<NtAction>();
-
-#endif // NTACTION_H

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -1,5 +1,4 @@
-#ifndef PRECURSORACTION_H
-#define PRECURSORACTION_H
+#pragma once
 
 #include "VariableNotAMooseObjectAction.h"
 
@@ -21,12 +20,13 @@ class PrecursorAction : public VariableNotAMooseObjectAction
 public:
   PrecursorAction(const InputParameters & params);
 
-  void act() override;
+  static InputParameters validParams();
 
   using Action::addRelationshipManagers;
   void addRelationshipManagers(Moose::RelationshipManagerType when_type) override;
 
 protected:
+  void act() override;
 
   /**
   * Adds PrecursorSource kernel
@@ -127,8 +127,3 @@ protected:
   /// optional object name suffix
   std::string _object_suffix;
 };
-
-template <>
-InputParameters validParams<PrecursorAction>();
-
-#endif // PRECURSORACTION_H

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -22,10 +22,9 @@ public:
 
   static InputParameters validParams();
 
+  virtual void act() override;
 
 protected:
-  void act() override;
-
   using Action::addRelationshipManagers;
   void addRelationshipManagers(Moose::RelationshipManagerType when_type) override;
 

--- a/include/actions/PrecursorAction.h
+++ b/include/actions/PrecursorAction.h
@@ -22,11 +22,12 @@ public:
 
   static InputParameters validParams();
 
-  using Action::addRelationshipManagers;
-  void addRelationshipManagers(Moose::RelationshipManagerType when_type) override;
 
 protected:
   void act() override;
+
+  using Action::addRelationshipManagers;
+  void addRelationshipManagers(Moose::RelationshipManagerType when_type) override;
 
   /**
   * Adds PrecursorSource kernel

--- a/include/actions/VariableNotAMooseObjectAction.h
+++ b/include/actions/VariableNotAMooseObjectAction.h
@@ -7,6 +7,8 @@ class VariableNotAMooseObjectAction : public Action
 public:
   VariableNotAMooseObjectAction(const InputParameters & params);
 
+  static InputParameters validParams();
+
 protected:
   /**
    * Get the block ids from the input parameters
@@ -20,6 +22,3 @@ protected:
    */
   void addVariable(const std::string & var_name);
 };
-
-template <>
-InputParameters validParams<VariableNotAMooseObjectAction>();

--- a/include/auxkernels/ConstantDifferenceAux.h
+++ b/include/auxkernels/ConstantDifferenceAux.h
@@ -1,13 +1,6 @@
-#ifndef CONSTANTDIFFERENCEAUX_H
-#define CONSTANTDIFFERENCEAUX_H
+#pragma once
 
 #include "AuxKernel.h"
-
-// Forward Declarations
-class ConstantDifferenceAux;
-
-template <>
-InputParameters validParams<ConstantDifferenceAux>();
 
 /**
  * The original intention of this aux kernel is to compute a delta T about some
@@ -21,11 +14,11 @@ class ConstantDifferenceAux : public AuxKernel
 public:
   ConstantDifferenceAux(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeValue() override;
 
   const VariableValue & _variable;
   const Real & _constant;
 };
-
-#endif // CONSTANTDIFFERENCEAUX_H

--- a/include/auxkernels/FissionHeatSourceAux.h
+++ b/include/auxkernels/FissionHeatSourceAux.h
@@ -1,13 +1,6 @@
-#ifndef FISSIONEHEATSOURCEAUX_H
-#define FISSIONEHEATSOURCEAUX_H
+#pragma once
 
 #include "AuxKernel.h"
-
-// Forward Declarations
-class FissionHeatSourceAux;
-
-template <>
-InputParameters validParams<FissionHeatSourceAux>();
 
 /**
  * computes the heating term due to fissions.
@@ -23,8 +16,10 @@ class FissionHeatSourceAux : public AuxKernel
 public:
   FissionHeatSourceAux(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const MaterialProperty<std::vector<Real>> & _fissxs;
   const MaterialProperty<std::vector<Real>> & _fisse;
@@ -34,5 +29,3 @@ protected:
   std::vector<const VariableValue *> _group_fluxes;
   std::vector<unsigned int> _flux_ids;
 };
-
-#endif // FISSIONEHEATSOURCE_H

--- a/include/auxkernels/FissionHeatSourceTransientAux.h
+++ b/include/auxkernels/FissionHeatSourceTransientAux.h
@@ -1,13 +1,6 @@
-#ifndef FISSIONHEATSOURCETRANSIENTAUX_H
-#define FISSIONHEATSOURCETRANSIENTAUX_H
+#pragma once
 
 #include "AuxKernel.h"
-
-// Forward Declarations
-class FissionHeatSourceTransientAux;
-
-template <>
-InputParameters validParams<FissionHeatSourceTransientAux>();
 
 /**
  * Computes heat source due to fission during a transient.
@@ -21,8 +14,10 @@ class FissionHeatSourceTransientAux : public AuxKernel
 public:
   FissionHeatSourceTransientAux(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const MaterialProperty<std::vector<Real>> & _fissxs;
   const MaterialProperty<std::vector<Real>> & _fisse;
@@ -30,5 +25,3 @@ protected:
   Real _nt_scale;
   std::vector<const VariableValue *> _group_fluxes;
 };
-
-#endif // FISSIONHEATSOURCETRANSIENTAUX_H

--- a/include/auxkernels/MatDiffusionAux.h
+++ b/include/auxkernels/MatDiffusionAux.h
@@ -1,14 +1,7 @@
-#ifndef MATDIFFUSIONAUX_H
-#define MATDIFFUSIONAUX_H
+#pragma once
 
 #include "AuxKernel.h"
 #include "MaterialProperty.h"
-
-// Forward Declaration
-class MatDiffusionAux;
-
-template <>
-InputParameters validParams<MatDiffusionAux>();
 
 /**
  * Computes the Euclidean norm of the flux of some diffusing variable at
@@ -23,12 +16,12 @@ class MatDiffusionAux : public AuxKernel
 public:
   MatDiffusionAux(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   std::string _prop_name;
   const VariableGradient & _grad_diffuse_var;
   const MaterialProperty<Real> * _diff;
 };
-
-#endif // MATDIFFUSIONAUX_H

--- a/include/auxkernels/ModeratorHeatSourceTransientAux.h
+++ b/include/auxkernels/ModeratorHeatSourceTransientAux.h
@@ -1,13 +1,6 @@
-#ifndef MODERATORHEATSOURCETRANSIENTAUX_H
-#define MODERATORHEATSOURCETRANSIENTAUX_H
+#pragma once
 
 #include "AuxKernel.h"
-
-// Forward Declarations
-class ModeratorHeatSourceTransientAux;
-
-template <>
-InputParameters validParams<ModeratorHeatSourceTransientAux>();
 
 /**
  * When a reactor runs, gamma rays are emitted in extraordinary quantity.
@@ -26,11 +19,11 @@ class ModeratorHeatSourceTransientAux : public AuxKernel
 public:
   ModeratorHeatSourceTransientAux(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeValue();
+  virtual Real computeValue() override;
 
   const PostprocessorValue & _average_fission_heat;
   const Function & _gamma;
 };
-
-#endif // MODERATORHEATSOURCETRANSIENTAUX_H

--- a/include/base/MoltresApp.h
+++ b/include/base/MoltresApp.h
@@ -1,22 +1,17 @@
-#ifndef MAGMARAPP_H
-#define MAGMARAPP_H
+#pragma once
 
 #include "MooseApp.h"
-
-class MoltresApp;
-
-template <>
-InputParameters validParams<MoltresApp>();
 
 class MoltresApp : public MooseApp
 {
 public:
   MoltresApp(InputParameters parameters);
+
+  static InputParameters validParams();
+
   virtual ~MoltresApp();
 
   static void registerApps();
   static void registerAll(Factory & factory, ActionFactory & action_factory, Syntax & syntax);
   static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
 };
-
-#endif /* MAGMARAPP_H */

--- a/include/base/ScalarTransportBase.h
+++ b/include/base/ScalarTransportBase.h
@@ -1,13 +1,7 @@
-#ifndef SCALARTRANSPORTBASE_H
-#define SCALARTRANSPORTBASE_H
+#pragma once
 
 #include "InputParameters.h"
 #include "MooseVariableBase.h"
-
-class ScalarTransportBase;
-
-template <>
-InputParameters validParams<ScalarTransportBase>();
 
 /**
  * This class is useful for calculating the concentration, independent
@@ -19,6 +13,8 @@ class ScalarTransportBase
 {
 public:
   ScalarTransportBase(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   /// Computes \f$c\f$
   virtual Real computeConcentration(const VariableValue & u, unsigned int qp);
@@ -59,5 +55,3 @@ private:
   /// Boolean flag that determines whether to use the exponential/logarithmic formulation
   const bool _use_exp_form;
 };
-
-#endif // SCALARTRANSPORTBASE_H

--- a/include/bcs/ConservativeAdvectionNoBCBC.h
+++ b/include/bcs/ConservativeAdvectionNoBCBC.h
@@ -1,24 +1,17 @@
-#ifndef CONSERVATIVEADVECTIONOBCBC_H
-#define CONSERVATIVEADVECTIONOBCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-// Forward Declaration
-class ConservativeAdvectionNoBCBC;
-
-template <>
-InputParameters validParams<ConservativeAdvectionNoBCBC>();
 
 class ConservativeAdvectionNoBCBC : public IntegratedBC
 {
 public:
   ConservativeAdvectionNoBCBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   RealVectorValue _velocity;
 };
-
-#endif // CONSERVATIVEADVECTIONOBCBC_H

--- a/include/bcs/CoupledOutflowBC.h
+++ b/include/bcs/CoupledOutflowBC.h
@@ -1,13 +1,6 @@
-#ifndef COUPLEDOUTFLOWBC_H
-#define COUPLEDOUTFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-// Forward Declarations
-class CoupledOutflowBC;
-
-template<>
-InputParameters validParams<CoupledOutflowBC>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -19,6 +12,8 @@ class CoupledOutflowBC : public IntegratedBC
 public:
   CoupledOutflowBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
@@ -29,5 +24,3 @@ private:
   const VariableValue & _vel_y;
   const VariableValue & _vel_z;
 };
-
-#endif // COUPLEDOUTFLOWBC_H

--- a/include/bcs/CoupledScalarAdvectionNoBCBC.h
+++ b/include/bcs/CoupledScalarAdvectionNoBCBC.h
@@ -1,14 +1,7 @@
-#ifndef COUPLEDSCALARADVECTIONNOBCBC_H
-#define COUPLEDSCALARADVECTIONNOBCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class CoupledScalarAdvectionNoBCBC;
-
-template <>
-InputParameters validParams<CoupledScalarAdvectionNoBCBC>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -19,12 +12,14 @@ class CoupledScalarAdvectionNoBCBC : public IntegratedBC, public ScalarTransport
 public:
   CoupledScalarAdvectionNoBCBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~CoupledScalarAdvectionNoBCBC() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   // Coupled variables
   const VariableValue & _u_vel;
@@ -41,5 +36,3 @@ protected:
   VariableValue _w_def;
   Real _conc_scaling;
 };
-
-#endif // COUPLEDSCALARADVECTIONNOBCBC_H

--- a/include/bcs/DiffusionNoBCBC.h
+++ b/include/bcs/DiffusionNoBCBC.h
@@ -1,12 +1,6 @@
-#ifndef DIFFUSIONNOBCBC_H
-#define DIFFUSIONNOBCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-class DiffusionNoBCBC;
-
-template <>
-InputParameters validParams<DiffusionNoBCBC>();
 
 /**
  * This kernel implements the Laplacian operator:
@@ -17,10 +11,10 @@ class DiffusionNoBCBC : public IntegratedBC
 public:
   DiffusionNoBCBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual() override;
 
   virtual Real computeQpJacobian() override;
 };
-
-#endif /* DIFFUSIONNOBCBC_H */

--- a/include/bcs/INSOutflowBC.h
+++ b/include/bcs/INSOutflowBC.h
@@ -1,13 +1,6 @@
-#ifndef INSOUTFLOWBC_H
-#define INSOUTFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-// Forward Declarations
-class INSOutflowBC;
-
-template <>
-InputParameters validParams<INSOutflowBC>();
 
 /**
  * This class computes momentum equation residual and Jacobian
@@ -19,12 +12,14 @@ class INSOutflowBC : public IntegratedBC
 public:
   INSOutflowBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~INSOutflowBC() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   // Coupled variables
   const VariableValue & _u_vel;
@@ -53,5 +48,3 @@ protected:
   unsigned _component;
   bool _integrate_p_by_parts;
 };
-
-#endif // INSOUTFLOWBC_H

--- a/include/bcs/INSSymmetryAxisBC.h
+++ b/include/bcs/INSSymmetryAxisBC.h
@@ -1,13 +1,6 @@
-#ifndef INSSYMMETRYAXISBC_H
-#define INSSYMMETRYAXISBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-// Forward Declarations
-class INSSymmetryAxisBC;
-
-template <>
-InputParameters validParams<INSSymmetryAxisBC>();
 
 /**
  * This class computes momentum equation residual and Jacobian
@@ -19,12 +12,14 @@ class INSSymmetryAxisBC : public IntegratedBC
 public:
   INSSymmetryAxisBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~INSSymmetryAxisBC() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   // Coupled variables
   const VariableValue & _u_vel;
@@ -53,5 +48,3 @@ protected:
   unsigned _component;
   bool _integrate_p_by_parts;
 };
-
-#endif // INSSYMMETRYAXISBC_H

--- a/include/bcs/LinLogPenaltyDirichletBC.h
+++ b/include/bcs/LinLogPenaltyDirichletBC.h
@@ -1,18 +1,14 @@
-#ifndef LINLOGPENALTYDIRICHLETBC_H
-#define LINLOGPENALTYDIRICHLETBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "ScalarTransportBase.h"
-
-class LinLogPenaltyDirichletBC;
-
-template <>
-InputParameters validParams<LinLogPenaltyDirichletBC>();
 
 class LinLogPenaltyDirichletBC : public IntegratedBC, public ScalarTransportBase
 {
 public:
   LinLogPenaltyDirichletBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -22,5 +18,3 @@ private:
   Real _p;
   Real _v;
 };
-
-#endif

--- a/include/bcs/MatDiffusionFluxBC.h
+++ b/include/bcs/MatDiffusionFluxBC.h
@@ -1,22 +1,16 @@
-#ifndef MATDIFFUSIONFLUXBC_H
-#define MATDIFFUSIONFLUXBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-class MatDiffusionFluxBC;
-
-template <>
-InputParameters validParams<MatDiffusionFluxBC>();
 
 class MatDiffusionFluxBC : public IntegratedBC
 {
 public:
   MatDiffusionFluxBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
   const MaterialProperty<Real> * _diff;
 };
-
-#endif /* MATDIFFUSIONFLUXBC_H */

--- a/include/bcs/PostprocessorCoupledInflowBC.h
+++ b/include/bcs/PostprocessorCoupledInflowBC.h
@@ -1,12 +1,6 @@
-#ifndef POSTPROCESSORCOUPLEDINFLOWBC_H
-#define POSTPROCESSORCOUPLEDINFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
-
-class PostprocessorCoupledInflowBC;
-
-template <>
-InputParameters validParams<PostprocessorCoupledInflowBC>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -17,6 +11,8 @@ class PostprocessorCoupledInflowBC : public IntegratedBC
 {
 public:
   PostprocessorCoupledInflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   const PostprocessorValue & _pp_value;
@@ -31,5 +27,3 @@ private:
   const VariableValue & _vel_y;
   const VariableValue & _vel_z;
 };
-
-#endif // POSTPROCESSORCOUPLEDINFLOWBC_H

--- a/include/bcs/ScalarAdvectionArtDiffNoBCBC.h
+++ b/include/bcs/ScalarAdvectionArtDiffNoBCBC.h
@@ -1,14 +1,7 @@
-#ifndef SCALARADVECTIONARTDIFFNOBCBC_H
-#define SCALARADVECTIONARTDIFFNOBCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class ScalarAdvectionArtDiffNoBCBC;
-
-template <>
-InputParameters validParams<ScalarAdvectionArtDiffNoBCBC>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -19,12 +12,14 @@ class ScalarAdvectionArtDiffNoBCBC : public IntegratedBC, public ScalarTransport
 public:
   ScalarAdvectionArtDiffNoBCBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~ScalarAdvectionArtDiffNoBCBC() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   Real _scale;
   // Coupled variables
@@ -43,5 +38,3 @@ protected:
   Real _conc_scaling;
   Real _tau;
 };
-
-#endif // SCALARADVECTIONARTDIFFNOBCBC_H

--- a/include/bcs/VacuumConcBC.h
+++ b/include/bcs/VacuumConcBC.h
@@ -1,14 +1,7 @@
-#ifndef VACUUMCONCBC_H
-#define VACUUMCONCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class VacuumConcBC;
-
-template <>
-InputParameters validParams<VacuumConcBC>();
 
 /**
  * Implements a simple VacuumConc BC for neutron diffusion on the boundary.
@@ -25,6 +18,8 @@ public:
    */
   VacuumConcBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual() override;
 
@@ -33,5 +28,3 @@ protected:
   /// Ratio of u to du/dn
   Real _alpha;
 };
-
-#endif // VACUUMCONCBC_H

--- a/include/dirackernels/DiracHX.h
+++ b/include/dirackernels/DiracHX.h
@@ -1,14 +1,7 @@
-#ifndef DIRACHX_H
-#define DIRACHX_H
+#pragma once
 
 // Moose Includes
 #include "DiracKernel.h"
-
-// Forward Declarations
-class DiracHX;
-
-template <>
-InputParameters validParams<DiracHX>();
 
 /**
  * Provides a Dirac kernel for heating or cooling. At first,
@@ -25,6 +18,8 @@ class DiracHX : public DiracKernel
 public:
   DiracHX(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual void addPoints() override;
   virtual Real computeQpResidual() override;
 
@@ -32,5 +27,3 @@ protected:
   const Real & _power;
   Point _point;
 };
-
-#endif // DIRACHX_H

--- a/include/kernels/CoupledFissionEigenKernel.h
+++ b/include/kernels/CoupledFissionEigenKernel.h
@@ -1,14 +1,7 @@
-#ifndef COUPLEDFISSIONEIGENKERNEL_H
-#define COUPLEDFISSIONEIGENKERNEL_H
+#pragma once
 
 #include "EigenKernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class CoupledFissionEigenKernel;
-
-template <>
-InputParameters validParams<CoupledFissionEigenKernel>();
 
 /**
  * Computes the fission source normalized by eigenvalue. In other words:
@@ -20,6 +13,8 @@ class CoupledFissionEigenKernel : public EigenKernel, public ScalarTransportBase
 {
 public:
   CoupledFissionEigenKernel(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -36,5 +31,3 @@ protected:
   std::vector<unsigned int> _flux_ids;
   bool _account_delayed;
 };
-
-#endif // COUPLEDFISSIONEIGENKERNEL_H

--- a/include/kernels/CoupledFissionKernel.h
+++ b/include/kernels/CoupledFissionKernel.h
@@ -1,14 +1,7 @@
-#ifndef COUPLEDFISSIONKERNEL_H
-#define COUPLEDFISSIONKERNEL_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class CoupledFissionKernel;
-
-template <>
-InputParameters validParams<CoupledFissionKernel>();
 
 /**
  * Computes fission source of neutrons without normalizing by
@@ -19,10 +12,12 @@ class CoupledFissionKernel : public Kernel, public ScalarTransportBase
 public:
   CoupledFissionKernel(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _nsf;
   const MaterialProperty<std::vector<Real>> & _d_nsf_d_temp;
@@ -40,5 +35,3 @@ protected:
   std::vector<unsigned int> _flux_ids;
   bool _account_delayed;
 };
-
-#endif // COUPLEDFISSIONKERNEL_H

--- a/include/kernels/CoupledScalarAdvection.h
+++ b/include/kernels/CoupledScalarAdvection.h
@@ -1,14 +1,7 @@
-#ifndef COUPLEDSCALARADVECTION_H
-#define COUPLEDSCALARADVECTION_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class CoupledScalarAdvection;
-
-template <>
-InputParameters validParams<CoupledScalarAdvection>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -18,6 +11,8 @@ class CoupledScalarAdvection : public Kernel, public ScalarTransportBase
 {
 public:
   CoupledScalarAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~CoupledScalarAdvection() {}
 
@@ -42,5 +37,3 @@ protected:
 
   Real _conc_scaling;
 };
-
-#endif // COUPLEDSCALARADVECTION_H

--- a/include/kernels/DecayHeatSource.h
+++ b/include/kernels/DecayHeatSource.h
@@ -1,19 +1,14 @@
-#ifndef DECAYHEATSOURCE_H
-#define DECAYHEATSOURCE_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class DecayHeatSource;
-
-template <>
-InputParameters validParams<DecayHeatSource>();
 
 class DecayHeatSource : public Kernel, public ScalarTransportBase
 {
 public:
   DecayHeatSource(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -25,5 +20,3 @@ protected:
   std::vector<const VariableValue *> _heat_concs;
   std::vector<unsigned int> _heat_ids;
 };
-
-#endif // DECAYHEATSOURCE_H

--- a/include/kernels/DelayedNeutronEigenSource.h
+++ b/include/kernels/DelayedNeutronEigenSource.h
@@ -1,19 +1,14 @@
-#ifndef DELAYEDNEUTRONEIGENSOURCE_H
-#define DELAYEDNEUTRONEIGENSOURCE_H
+#pragma once
 
 #include "EigenKernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class DelayedNeutronEigenSource;
-
-template <>
-InputParameters validParams<DelayedNeutronEigenSource>();
 
 class DelayedNeutronEigenSource : public EigenKernel, public ScalarTransportBase
 {
 public:
   DelayedNeutronEigenSource(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -32,5 +27,3 @@ protected:
   std::vector<const VariableValue *> _pre_concs;
   std::vector<unsigned int> _pre_ids;
 };
-
-#endif // DELAYEDNEUTRONEIGENSOURCE_H

--- a/include/kernels/DelayedNeutronSource.h
+++ b/include/kernels/DelayedNeutronSource.h
@@ -1,19 +1,14 @@
-#ifndef DELAYEDNEUTRONSOURCE_H
-#define DELAYEDNEUTRONSOURCE_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class DelayedNeutronSource;
-
-template <>
-InputParameters validParams<DelayedNeutronSource>();
 
 class DelayedNeutronSource : public Kernel, public ScalarTransportBase
 {
 public:
   DelayedNeutronSource(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -32,5 +27,3 @@ protected:
   std::vector<const VariableValue *> _pre_concs;
   std::vector<unsigned int> _pre_ids;
 };
-
-#endif // DELAYEDNEUTRONSOURCE_H

--- a/include/kernels/DivFreeCoupledScalarAdvection.h
+++ b/include/kernels/DivFreeCoupledScalarAdvection.h
@@ -1,14 +1,7 @@
-#ifndef DIVFREECOUPLEDSCALARADVECTION_H
-#define DIVFREECOUPLEDSCALARADVECTION_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class DivFreeCoupledScalarAdvection;
-
-template <>
-InputParameters validParams<DivFreeCoupledScalarAdvection>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -18,6 +11,8 @@ class DivFreeCoupledScalarAdvection : public Kernel, public ScalarTransportBase
 {
 public:
   DivFreeCoupledScalarAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~DivFreeCoupledScalarAdvection() {}
 
@@ -41,5 +36,3 @@ protected:
   VariableValue _w_def;
   Real _conc_scaling;
 };
-
-#endif // DIVFREECOUPLEDSCALARADVECTION_H

--- a/include/kernels/FissionHeatSource.h
+++ b/include/kernels/FissionHeatSource.h
@@ -1,12 +1,6 @@
-#ifndef FISSIONEHEATSOURCE_H
-#define FISSIONEHEATSOURCE_H
+#pragma once
 
 #include "Kernel.h"
-
-class FissionHeatSource;
-
-template <>
-InputParameters validParams<FissionHeatSource>();
 
 /**
  * This kernel will likely only be used with k-eigenvalue calculation mode
@@ -17,10 +11,12 @@ class FissionHeatSource : public Kernel
 public:
   FissionHeatSource(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _fissxs;
   const MaterialProperty<std::vector<Real>> & _d_fissxs_d_temp;
@@ -32,5 +28,3 @@ protected:
   std::vector<const VariableValue *> _group_fluxes;
   std::vector<unsigned int> _flux_ids;
 };
-
-#endif // FISSIONEHEATSOURCE_H

--- a/include/kernels/GammaHeatSource.h
+++ b/include/kernels/GammaHeatSource.h
@@ -1,25 +1,18 @@
-#ifndef GAMMAEHEATSOURCE_H
-#define GAMMAEHEATSOURCE_H
+#pragma once
 
 #include "Kernel.h"
-
-// Forward Declarations
-class GammaHeatSource;
-
-template <>
-InputParameters validParams<GammaHeatSource>();
 
 class GammaHeatSource : public Kernel
 {
 public:
   GammaHeatSource(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   const PostprocessorValue & _average_fission_heat;
   const Function & _gamma;
 };
-
-#endif // GAMMAEHEATSOURCE_H

--- a/include/kernels/GroupDiffusion.h
+++ b/include/kernels/GroupDiffusion.h
@@ -1,29 +1,22 @@
-#ifndef GROUPDIFFUSION_H
-#define GROUPDIFFUSION_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declaration
-class GroupDiffusion;
-
-template <>
-InputParameters validParams<GroupDiffusion>();
 
 class GroupDiffusion : public Kernel, public ScalarTransportBase
 {
 public:
   GroupDiffusion(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _diffcoef;
   const MaterialProperty<std::vector<Real>> & _d_diffcoef_d_temp;
   unsigned int _group;
   unsigned int _temp_id;
 };
-
-#endif // GROUPDIFFUSION_H

--- a/include/kernels/HeatPrecursorDecay.h
+++ b/include/kernels/HeatPrecursorDecay.h
@@ -1,14 +1,7 @@
-#ifndef HEATPRECURSORDECAY_H
-#define HEATPRECURSORDECAY_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class HeatPrecursorDecay;
-
-template <>
-InputParameters validParams<HeatPrecursorDecay>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -20,6 +13,8 @@ class HeatPrecursorDecay : public Kernel, public ScalarTransportBase
 public:
   HeatPrecursorDecay(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual() override;
   virtual Real computeQpJacobian() override;
@@ -27,5 +22,3 @@ protected:
   unsigned int _heat_group;
   std::vector<Real> _decay_heat_const;
 };
-
-#endif // HEATPRECURSORDECAY_H

--- a/include/kernels/HeatPrecursorSource.h
+++ b/include/kernels/HeatPrecursorSource.h
@@ -1,14 +1,7 @@
-#ifndef HEATPRECURSORSOURCE_H
-#define HEATPRECURSORSOURCE_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class HeatPrecursorSource;
-
-template <>
-InputParameters validParams<HeatPrecursorSource>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -19,6 +12,8 @@ class HeatPrecursorSource : public Kernel, public ScalarTransportBase
 {
 public:
   HeatPrecursorSource(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -41,5 +36,3 @@ protected:
   std::vector<const VariableValue *> _group_fluxes;
   std::vector<unsigned int> _flux_ids;
 };
-
-#endif // HEATPRECURSORSOURCE_H

--- a/include/kernels/INSBoussinesqBodyForce.h
+++ b/include/kernels/INSBoussinesqBodyForce.h
@@ -1,13 +1,6 @@
-#ifndef INSBOUSSINESQBODYFORCE_H
-#define INSBOUSSINESQBODYFORCE_H
+#pragma once
 
 #include "Kernel.h"
-
-// Forward Declarations
-class INSBoussinesqBodyForce;
-
-template <>
-InputParameters validParams<INSBoussinesqBodyForce>();
 
 /**
  * Computes a body force that approximates natural buoyancy in
@@ -19,11 +12,13 @@ class INSBoussinesqBodyForce : public Kernel
 public:
   INSBoussinesqBodyForce(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~INSBoussinesqBodyForce() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned jvar);
 
   // Parameters
@@ -37,5 +32,3 @@ protected:
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _T_ref;
 };
-
-#endif

--- a/include/kernels/INSMomentumKEpsilon.h
+++ b/include/kernels/INSMomentumKEpsilon.h
@@ -1,13 +1,6 @@
-#ifndef INSMOMENTUMKEPSILON_H
-#define INSMOMENTUMKEPSILON_H
+#pragma once
 
 #include "Kernel.h"
-
-// Forward Declarations
-class INSMomentumKEpsilon;
-
-template <>
-InputParameters validParams<INSMomentumKEpsilon>();
 
 /**
  * This class computes momentum equation residual and Jacobian
@@ -19,12 +12,14 @@ class INSMomentumKEpsilon : public Kernel
 public:
   INSMomentumKEpsilon(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
   virtual ~INSMomentumKEpsilon() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   // Coupled variables
   const VariableValue & _u_vel;
@@ -57,5 +52,3 @@ protected:
   unsigned _component;
   bool _integrate_p_by_parts;
 };
-
-#endif // INSMOMENTUMKEPSILON_H

--- a/include/kernels/InScatter.h
+++ b/include/kernels/InScatter.h
@@ -1,25 +1,19 @@
-#ifndef INSCATTER_H
-#define INSCATTER_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declaration
-class InScatter;
-
-template <>
-InputParameters validParams<InScatter>();
 
 class InScatter : public Kernel, public ScalarTransportBase
 {
 public:
   InScatter(const InputParameters & parameters);
 
-protected:
-  virtual Real computeQpResidual();
+  static InputParameters validParams();
 
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _gtransfxs;
   const MaterialProperty<std::vector<Real>> & _d_gtransfxs_d_temp;
@@ -30,5 +24,3 @@ protected:
   std::vector<unsigned int> _flux_ids;
   bool _sss2_input;
 };
-
-#endif // INSCATTER_H

--- a/include/kernels/ManuHX.h
+++ b/include/kernels/ManuHX.h
@@ -1,25 +1,18 @@
-#ifndef MANUHX_H
-#define MANUHX_H
+#pragma once
 
 #include "Kernel.h"
-
-// Forward Declarations
-class ManuHX;
-
-template <>
-InputParameters validParams<ManuHX>();
 
 class ManuHX : public Kernel
 {
 public:
   ManuHX(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   Real _htc;
   Real _tref;
 };
-
-#endif // MANUHX_H

--- a/include/kernels/NtTimeDerivative.h
+++ b/include/kernels/NtTimeDerivative.h
@@ -1,18 +1,13 @@
-#ifndef NTTIMEDERIVATIVE_H
-#define NTTIMEDERIVATIVE_H
+#pragma once
 
 #include "ScalarTransportTimeDerivative.h"
-
-// Forward Declaration
-class NtTimeDerivative;
-
-template <>
-InputParameters validParams<NtTimeDerivative>();
 
 class NtTimeDerivative : public ScalarTransportTimeDerivative
 {
 public:
   NtTimeDerivative(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;
@@ -24,5 +19,3 @@ protected:
   unsigned int _group;
   unsigned int _temp_id;
 };
-
-#endif // NTTIMEDERIVATIVE_H

--- a/include/kernels/PrecursorDecay.h
+++ b/include/kernels/PrecursorDecay.h
@@ -1,24 +1,19 @@
-#ifndef PRECURSORDECAY_H
-#define PRECURSORDECAY_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class PrecursorDecay;
-
-template <>
-InputParameters validParams<PrecursorDecay>();
 
 class PrecursorDecay : public Kernel, public ScalarTransportBase
 {
 public:
   PrecursorDecay(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _decay_constant;
   const MaterialProperty<std::vector<Real>> & _d_decay_constant_d_temp;
@@ -27,5 +22,3 @@ protected:
   const VariableValue & _temp;
   Real _prec_scale;
 };
-
-#endif // PRECURSORDECAY_H

--- a/include/kernels/PrecursorSource.h
+++ b/include/kernels/PrecursorSource.h
@@ -1,24 +1,19 @@
-#ifndef PRECURSORSOURCE_H
-#define PRECURSORSOURCE_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class PrecursorSource;
-
-template <>
-InputParameters validParams<PrecursorSource>();
 
 class PrecursorSource : public Kernel, public ScalarTransportBase
 {
 public:
   PrecursorSource(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _nsf;
   const MaterialProperty<std::vector<Real>> & _d_nsf_d_temp;
@@ -32,5 +27,3 @@ protected:
   std::vector<unsigned int> _flux_ids;
   Real _prec_scale;
 };
-
-#endif // PRECURSORSOURCE_H

--- a/include/kernels/ScalarAdvectionArtDiff.h
+++ b/include/kernels/ScalarAdvectionArtDiff.h
@@ -1,14 +1,7 @@
-#ifndef SCALARADVECTIONARTDIFF_H
-#define SCALARADVECTIONARTDIFF_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class ScalarAdvectionArtDiff;
-
-template <>
-InputParameters validParams<ScalarAdvectionArtDiff>();
 
 /**
  * This class computes the residual and Jacobian contributions for the
@@ -31,6 +24,8 @@ class ScalarAdvectionArtDiff : public Kernel, public ScalarTransportBase
 {
 public:
   ScalarAdvectionArtDiff(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~ScalarAdvectionArtDiff() {}
 
@@ -58,5 +53,3 @@ protected:
   Real _conc_scaling;
   const Real & _current_elem_volume;
 };
-
-#endif // SCALARADVECTIONARTDIFF_H

--- a/include/kernels/ScalarTransportTimeDerivative.h
+++ b/include/kernels/ScalarTransportTimeDerivative.h
@@ -1,26 +1,19 @@
-#ifndef SCALARTRANSPORTTIMEDERIVATIVE_H
-#define SCALARTRANSPORTTIMEDERIVATIVE_H
+#pragma once
 
 #include "TimeKernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declaration
-class ScalarTransportTimeDerivative;
-
-template <>
-InputParameters validParams<ScalarTransportTimeDerivative>();
 
 class ScalarTransportTimeDerivative : public TimeKernel, public ScalarTransportBase
 {
 public:
   ScalarTransportTimeDerivative(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   bool _lumping;
   Real _conc_scaling;
 };
-
-#endif // SCALARTRANSPORTTIMEDERIVATIVE_H

--- a/include/kernels/SelfFissionEigenKernel.h
+++ b/include/kernels/SelfFissionEigenKernel.h
@@ -1,25 +1,18 @@
-#ifndef SELFFISSIONEIGENKERNEL_H
-#define SELFFISSIONEIGENKERNEL_H
+#pragma once
 
 #include "EigenKernel.h"
-
-// Forward Declarations
-class SelfFissionEigenKernel;
-
-template <>
-InputParameters validParams<SelfFissionEigenKernel>();
 
 class SelfFissionEigenKernel : public EigenKernel
 {
 public:
   SelfFissionEigenKernel(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   const MaterialProperty<Real> & _nu_f;
   const MaterialProperty<Real> & _sigma_f;
 };
-
-#endif // SELFFISSIONEIGENKERNEL_H

--- a/include/kernels/SigmaR.h
+++ b/include/kernels/SigmaR.h
@@ -1,29 +1,22 @@
-#ifndef SIGMAR_H
-#define SIGMAR_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declaration
-class SigmaR;
-
-template <>
-InputParameters validParams<SigmaR>();
 
 class SigmaR : public Kernel, public ScalarTransportBase
 {
 public:
   SigmaR(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   const MaterialProperty<std::vector<Real>> & _remxs;
   const MaterialProperty<std::vector<Real>> & _d_remxs_d_temp;
   unsigned int _group;
   unsigned int _temp_id;
 };
-
-#endif // SIGMAR_H

--- a/include/kernels/TransientFissionHeatSource.h
+++ b/include/kernels/TransientFissionHeatSource.h
@@ -1,14 +1,7 @@
-#ifndef TRANSIENTFISSIONEHEATSOURCE_H
-#define TRANSIENTFISSIONEHEATSOURCE_H
+#pragma once
 
 #include "Kernel.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class TransientFissionHeatSource;
-
-template <>
-InputParameters validParams<TransientFissionHeatSource>();
 
 /**
  * This class computes the residual and Jacobian contributions of the
@@ -20,10 +13,12 @@ class TransientFissionHeatSource : public Kernel, public ScalarTransportBase
 public:
   TransientFissionHeatSource(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
   // Material properties
   const MaterialProperty<std::vector<Real>> & _fissxs;
@@ -42,5 +37,3 @@ protected:
   std::vector<const VariableValue *> _heat_concs;
   std::vector<unsigned int> _heat_ids;
 };
-
-#endif // TRANSIENTFISSIONEHEATSOURCE_H

--- a/include/materials/CammiFuel.h
+++ b/include/materials/CammiFuel.h
@@ -1,25 +1,19 @@
-#ifndef CAMMIFUEL_H_
-#define CAMMIFUEL_H_
+#pragma once
 
 #include "GenericMoltresMaterial.h"
 #include "SplineInterpolation.h"
 #include "BicubicSplineInterpolation.h"
-
-class CammiFuel;
-
-template <>
-InputParameters validParams<CammiFuel>();
 
 class CammiFuel : public GenericMoltresMaterial
 {
 public:
   CammiFuel(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   MaterialProperty<Real> & _rho;
   MaterialProperty<Real> & _k;
 };
-
-#endif // CAMMIFUEL_H

--- a/include/materials/CammiModerator.h
+++ b/include/materials/CammiModerator.h
@@ -1,24 +1,18 @@
-#ifndef CAMMIMODERATOR_H_
-#define CAMMIMODERATOR_H_
+#pragma once
 
 #include "GenericMoltresMaterial.h"
 #include "SplineInterpolation.h"
 #include "BicubicSplineInterpolation.h"
-
-class CammiModerator;
-
-template <>
-InputParameters validParams<CammiModerator>();
 
 class CammiModerator : public GenericMoltresMaterial
 {
 public:
   CammiModerator(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   MaterialProperty<Real> & _k;
 };
-
-#endif // CAMMIMODERATOR_H

--- a/include/materials/GenericMoltresMaterial.h
+++ b/include/materials/GenericMoltresMaterial.h
@@ -1,5 +1,4 @@
-#ifndef GENERICMOLTRESMATERIAL_H_
-#define GENERICMOLTRESMATERIAL_H_
+#pragma once
 
 #include "NuclearMaterial.h"
 #include "SplineInterpolation.h"
@@ -7,15 +6,12 @@
 #include "MonotoneCubicInterpolation.h"
 #include "LinearInterpolation.h"
 
-class GenericMoltresMaterial;
-
-template <>
-InputParameters validParams<GenericMoltresMaterial>();
-
 class GenericMoltresMaterial : public NuclearMaterial
 {
 public:
   GenericMoltresMaterial(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   void dummyConstruct(std::string & property_tables_root, std::vector<std::string> xsec_names);
@@ -28,7 +24,7 @@ protected:
                               const InputParameters & parameters);
   void leastSquaresConstruct(std::string & property_tables_root,
                              std::vector<std::string> xsec_names);
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
   virtual void dummyComputeQpProperties();
   virtual void fuelBicubic();
   virtual void moderatorBicubic();
@@ -44,5 +40,3 @@ protected:
   std::string _material;
   bool _perform_control;
 };
-
-#endif // GENERICMOLTRESMATERIAL_H

--- a/include/materials/GraphiteTwoGrpXSFunctionMaterial.h
+++ b/include/materials/GraphiteTwoGrpXSFunctionMaterial.h
@@ -1,5 +1,4 @@
-#ifndef GRAPHITETWOGRPXSFUNCTIONMATERIAL_H_
-#define GRAPHITETWOGRPXSFUNCTIONMATERIAL_H_
+#pragma once
 
 #include "GenericConstantMaterial.h"
 #include "SplineInterpolation.h"
@@ -7,18 +6,15 @@
 #include "MonotoneCubicInterpolation.h"
 #include "LinearInterpolation.h"
 
-class GraphiteTwoGrpXSFunctionMaterial;
-
-template <>
-InputParameters validParams<GraphiteTwoGrpXSFunctionMaterial>();
-
 class GraphiteTwoGrpXSFunctionMaterial : public GenericConstantMaterial
 {
 public:
   GraphiteTwoGrpXSFunctionMaterial(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   const VariableValue & _T;
   // const MaterialProperty<Real> & _rho;
@@ -48,5 +44,3 @@ protected:
   MaterialProperty<Real> & _d_beta_d_temp;
   MaterialProperty<std::vector<Real>> & _d_decay_constant_d_temp;
 };
-
-#endif // GRAPHITETWOGRPXSFUNCTIONMATERIAL_H

--- a/include/materials/MoltresJsonMaterial.h
+++ b/include/materials/MoltresJsonMaterial.h
@@ -1,24 +1,18 @@
-#ifndef MOLTRESJSONMATERIAL_H_
-#define MOLTRESJSONMATERIAL_H_
+#pragma once
 
 #include "NuclearMaterial.h"
 #include "nlohmann/json.h"
-
-class MoltresJsonMaterial;
-
-template <>
-InputParameters validParams<MoltresJsonMaterial>();
 
 class MoltresJsonMaterial : public NuclearMaterial
 {
 public:
   MoltresJsonMaterial(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   void Construct(nlohmann::json xs_root, std::vector<std::string> xsec_names);
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   std::string _material_key;
 };
-
-#endif // MOLTRESJSONMATERIAL_H

--- a/include/materials/MsreFuelTwoGrpXSFunctionMaterial.h
+++ b/include/materials/MsreFuelTwoGrpXSFunctionMaterial.h
@@ -1,5 +1,4 @@
-#ifndef MSREFUELTWOGRPXSFUNCTIONMATERIAL_H_
-#define MSREFUELTWOGRPXSFUNCTIONMATERIAL_H_
+#pragma once
 
 #include "GenericConstantMaterial.h"
 #include "SplineInterpolation.h"
@@ -7,18 +6,15 @@
 #include "MonotoneCubicInterpolation.h"
 #include "LinearInterpolation.h"
 
-class MsreFuelTwoGrpXSFunctionMaterial;
-
-template <>
-InputParameters validParams<MsreFuelTwoGrpXSFunctionMaterial>();
-
 class MsreFuelTwoGrpXSFunctionMaterial : public GenericConstantMaterial
 {
 public:
   MsreFuelTwoGrpXSFunctionMaterial(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   const VariableValue & _T;
   // const MaterialProperty<Real> & _rho;
@@ -49,5 +45,3 @@ protected:
   MaterialProperty<Real> & _d_beta_d_temp;
   MaterialProperty<std::vector<Real>> & _d_decay_constant_d_temp;
 };
-
-#endif // MSREFUELTWOGRPXSFUNCTIONMATERIAL_H

--- a/include/materials/NuclearMaterial.h
+++ b/include/materials/NuclearMaterial.h
@@ -1,5 +1,4 @@
-#ifndef NUCLEARMATERIAL_H_
-#define NUCLEARMATERIAL_H_
+#pragma once
 
 #include "GenericConstantMaterial.h"
 #include "SplineInterpolation.h"
@@ -7,11 +6,6 @@
 #include "MonotoneCubicInterpolation.h"
 #include "LinearInterpolation.h"
 #include "json.h"
-
-class NuclearMaterial;
-
-template <>
-InputParameters validParams<NuclearMaterial>();
 
 /**
  * This class hinges on the `interp_type` chosen by the user. The user can choose from the
@@ -40,6 +34,8 @@ class NuclearMaterial : public GenericConstantMaterial
 {
 public:
   NuclearMaterial(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   // correspond to descriptions above
   enum INTERPOLATOR
@@ -121,5 +117,3 @@ protected:
   std::vector<std::vector<Real>> _beta_eff_consts = std::vector<std::vector<Real>>(2);
   std::vector<std::vector<Real>> _decay_constants_consts = std::vector<std::vector<Real>>(2);
 };
-
-#endif // NUCLEARMATERIAL_H

--- a/include/materials/Nusselt.h
+++ b/include/materials/Nusselt.h
@@ -1,27 +1,21 @@
-#ifndef NUSSELT_H_
-#define NUSSELT_H_
+#pragma once
 
 #include "Material.h"
 #include "SplineInterpolation.h"
 #include "BicubicSplineInterpolation.h"
-
-class Nusselt;
-
-template <>
-InputParameters validParams<Nusselt>();
 
 class Nusselt : public Material
 {
 public:
   Nusselt(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
-  virtual void computeQpProperties();
+  virtual void computeQpProperties() override;
 
   const MaterialProperty<Real> & _k;
   Real _l_value;
   MaterialProperty<Real> & _nu;
   MaterialProperty<Real> & _h;
 };
-
-#endif // NUSSELT_H

--- a/include/materials/RoddedMaterial.h
+++ b/include/materials/RoddedMaterial.h
@@ -1,13 +1,7 @@
-#ifndef RODDEDMATERIAL_H_
-#define RODDEDMATERIAL_H_
+#pragma once
 
 #include "GenericMoltresMaterial.h"
 #include "ODEKernel.h"
-
-class RoddedMaterial;
-
-template <>
-InputParameters validParams<RoddedMaterial>();
 
 /**
  * This class is meant to simulate a piece of material with a rod in it.
@@ -27,6 +21,8 @@ class RoddedMaterial : public GenericMoltresMaterial
 public:
   RoddedMaterial(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   void splineConstruct(std::string & property_tables_root, std::vector<std::string> xsec_names);
   virtual void computeQpProperties() override;
@@ -36,5 +32,3 @@ protected:
   const VariableValue & _rod_pos;
   MooseEnum _rod_dim;
 };
-
-#endif // RODDEDMATERIAL_H

--- a/include/postprocessors/AverageFissionHeat.h
+++ b/include/postprocessors/AverageFissionHeat.h
@@ -1,26 +1,19 @@
-#ifndef AVERAGEFISSIONHEAT_H
-#define AVERAGEFISSIONHEAT_H
+#pragma once
 
 #include "ElmIntegTotFissHeatPostprocessor.h"
-
-// Forward Declarations
-class AverageFissionHeat;
-
-template <>
-InputParameters validParams<AverageFissionHeat>();
 
 class AverageFissionHeat : public ElmIntegTotFissHeatPostprocessor
 {
 public:
   AverageFissionHeat(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
+protected:
   virtual void initialize() override;
   virtual void execute() override;
   virtual Real getValue() override;
   virtual void threadJoin(const UserObject & y) override;
 
-protected:
   Real _volume;
 };
-
-#endif

--- a/include/postprocessors/DivisionPostprocessor.h
+++ b/include/postprocessors/DivisionPostprocessor.h
@@ -1,12 +1,6 @@
-#ifndef DIVISIONPOSTPROCESSOR_H
-#define DIVISIONPOSTPROCESSOR_H
+#pragma once
 
 #include "DifferencePostprocessor.h"
-
-class DivisionPostprocessor;
-
-template <>
-InputParameters validParams<DivisionPostprocessor>();
 
 /**
  * Computes the quotient between two postprocessors
@@ -18,7 +12,8 @@ class DivisionPostprocessor : public DifferencePostprocessor
 public:
   DivisionPostprocessor(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
+protected:
   virtual PostprocessorValue getValue() override;
 };
-
-#endif /* DIVISIONPOSTPROCESSOR_H */

--- a/include/postprocessors/ElementL2Diff.h
+++ b/include/postprocessors/ElementL2Diff.h
@@ -1,29 +1,21 @@
-
-#ifndef ELEMENTL2DIFF_H
-#define ELEMENTL2DIFF_H
+#pragma once
 
 #include "ElementIntegralVariablePostprocessor.h"
-
-// Forward Declarations
-class ElementL2Diff;
-
-template <>
-InputParameters validParams<ElementL2Diff>();
 
 class ElementL2Diff : public ElementIntegralVariablePostprocessor
 {
 public:
   ElementL2Diff(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   /**
    * Get the L2 Error.
    */
-  virtual Real getValue();
+  virtual Real getValue() override;
 
-  virtual Real computeQpIntegral();
+  virtual Real computeQpIntegral() override;
 
   const VariableValue & _u_old;
 };
-
-#endif // ELEMENTL2DIFF_H

--- a/include/postprocessors/ElmIntegTotFissHeatPostprocessor.h
+++ b/include/postprocessors/ElmIntegTotFissHeatPostprocessor.h
@@ -1,23 +1,16 @@
-#ifndef ELMINTEGTOTFISSHEATPOSTPROCESSOR_H
-#define ELMINTEGTOTFISSHEATPOSTPROCESSOR_H
+#pragma once
 
 #include "ElmIntegTotFissPostprocessor.h"
-
-// Forward Declarations
-class ElmIntegTotFissHeatPostprocessor;
-
-template <>
-InputParameters validParams<ElmIntegTotFissHeatPostprocessor>();
 
 class ElmIntegTotFissHeatPostprocessor : public ElmIntegTotFissPostprocessor
 {
 public:
   ElmIntegTotFissHeatPostprocessor(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeFluxMultiplier(int index) override;
 
   const MaterialProperty<std::vector<Real>> & _fisse;
 };
-
-#endif

--- a/include/postprocessors/ElmIntegTotFissNtsPostprocessor.h
+++ b/include/postprocessors/ElmIntegTotFissNtsPostprocessor.h
@@ -1,20 +1,15 @@
-#ifndef ELMINTEGTOTFISSNTSPOSTPROCESSOR_H
-#define ELMINTEGTOTFISSNTSPOSTPROCESSOR_H
+#pragma once
 
 #include "ElementIntegralPostprocessor.h"
 #include "MooseVariableInterface.h"
-
-// Forward Declarations
-class ElmIntegTotFissNtsPostprocessor;
-
-template <>
-InputParameters validParams<ElmIntegTotFissNtsPostprocessor>();
 
 class ElmIntegTotFissNtsPostprocessor : public ElementIntegralPostprocessor
 /* public MooseVariableInterface */
 {
 public:
   ElmIntegTotFissNtsPostprocessor(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpIntegral() override;
@@ -24,5 +19,3 @@ protected:
   std::vector<MooseVariableFEBase *> _vars;
   std::vector<const VariableValue *> _group_fluxes;
 };
-
-#endif

--- a/include/postprocessors/ElmIntegTotFissPostprocessor.h
+++ b/include/postprocessors/ElmIntegTotFissPostprocessor.h
@@ -1,20 +1,14 @@
-#ifndef ELMINTEGTOTFISSPOSTPROCESSOR_H
-#define ELMINTEGTOTFISSPOSTPROCESSOR_H
+#pragma once
 
 #include "ElementIntegralPostprocessor.h"
 #include "ScalarTransportBase.h"
 
-// Forward Declarations
-class ElmIntegTotFissPostprocessor;
-
-template <>
-InputParameters validParams<ElmIntegTotFissPostprocessor>();
-
 class ElmIntegTotFissPostprocessor : public ElementIntegralPostprocessor, public ScalarTransportBase
 {
-
 public:
   ElmIntegTotFissPostprocessor(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpIntegral() override;
@@ -26,5 +20,3 @@ protected:
   Real _nt_scale;
   std::vector<const VariableValue *> _group_fluxes;
 };
-
-#endif

--- a/include/postprocessors/IntegralNewVariablePostprocessor.h
+++ b/include/postprocessors/IntegralNewVariablePostprocessor.h
@@ -1,15 +1,8 @@
-#ifndef INTEGRALNEWVARIABLEPOSTPROCESSOR_H
-#define INTEGRALNEWVARIABLEPOSTPROCESSOR_H
+#pragma once
 
 #include "ElementIntegralPostprocessor.h"
 #include "MooseVariableInterface.h"
 #include "ScalarTransportBase.h"
-
-// Forward Declarations
-class IntegralNewVariablePostprocessor;
-
-template <>
-InputParameters validParams<IntegralNewVariablePostprocessor>();
 
 /**
  * This postprocessor computes a volume integral of the specified variable.
@@ -24,6 +17,8 @@ class IntegralNewVariablePostprocessor : public ElementIntegralPostprocessor,
 public:
   IntegralNewVariablePostprocessor(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpIntegral() override;
 
@@ -34,5 +29,3 @@ protected:
   /// Holds the solution derivative at the current quadrature points
   const VariableValue & _u_dot;
 };
-
-#endif

--- a/include/postprocessors/IntegralOldVariablePostprocessor.h
+++ b/include/postprocessors/IntegralOldVariablePostprocessor.h
@@ -1,15 +1,8 @@
-#ifndef INTEGRALOLDVARIABLEPOSTPROCESSOR_H
-#define INTEGRALOLDVARIABLEPOSTPROCESSOR_H
+#pragma once
 
 #include "ElementIntegralPostprocessor.h"
 #include "ScalarTransportBase.h"
 #include "MooseVariableInterface.h"
-
-// Forward Declarations
-class IntegralOldVariablePostprocessor;
-
-template <>
-InputParameters validParams<IntegralOldVariablePostprocessor>();
 
 /**
  * This postprocessor computes a volume integral of the specified variable from the
@@ -25,6 +18,8 @@ class IntegralOldVariablePostprocessor : public ElementIntegralPostprocessor,
 public:
   IntegralOldVariablePostprocessor(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpIntegral() override;
 
@@ -33,5 +28,3 @@ protected:
   /// Holds the solution gradient at the current quadrature points
   const VariableGradient & _grad_u_old;
 };
-
-#endif

--- a/include/postprocessors/LimitK.h
+++ b/include/postprocessors/LimitK.h
@@ -12,21 +12,16 @@
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
-#ifndef LIMITK_H
-#define LIMITK_H
+#pragma once
 
 #include "TimestepSize.h"
-
-// Forward Declarations
-class LimitK;
-
-template <>
-InputParameters validParams<LimitK>();
 
 class LimitK : public TimestepSize
 {
 public:
   LimitK(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual void initialize() override {}
   virtual void execute() override {}
@@ -42,5 +37,3 @@ protected:
   const Real & _cutback_factor;
   const Real & _k_threshold;
 };
-
-#endif // LIMITK_H

--- a/include/postprocessors/SideWeightedIntegralPostprocessor.h
+++ b/include/postprocessors/SideWeightedIntegralPostprocessor.h
@@ -1,13 +1,6 @@
-#ifndef SIDEWEIGHTEDINTEGRALPOSTPROCESSOR_H
-#define SIDEWEIGHTEDINTEGRALPOSTPROCESSOR_H
+#pragma once
 
 #include "SideIntegralVariablePostprocessor.h"
-
-// Forward Declarations
-class SideWeightedIntegralPostprocessor;
-
-template <>
-InputParameters validParams<SideIntegralVariablePostprocessor>();
 
 /**
  * This postprocessor computes the weighted integral of a
@@ -16,9 +9,9 @@ InputParameters validParams<SideIntegralVariablePostprocessor>();
 class SideWeightedIntegralPostprocessor : public SideIntegralVariablePostprocessor
 {
 public:
-  static InputParameters validParams();
-
   SideWeightedIntegralPostprocessor(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpIntegral() override;
@@ -26,5 +19,3 @@ protected:
   // Weight variable
   const VariableValue & _weight;
 };
-
-#endif // SIDEWEIGHTEDINTEGRALPOSTPROCESSOR_H

--- a/src/actions/NtAction.C
+++ b/src/actions/NtAction.C
@@ -23,11 +23,10 @@ registerMooseAction("MoltresApp", NtAction, "check_copy_nodal_vars");
 
 registerMooseAction("MoltresApp", NtAction, "copy_nodal_vars");
 
-template <>
 InputParameters
-validParams<NtAction>()
+NtAction::validParams()
 {
-  InputParameters params = validParams<VariableNotAMooseObjectAction>();
+  InputParameters params = VariableNotAMooseObjectAction::validParams();
 
   params.addRequiredParam<unsigned int>("num_precursor_groups",
                                         "specifies the total number of precursors to create");

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -101,7 +101,7 @@ PrecursorAction::PrecursorAction(const InputParameters & params)
 void
 PrecursorAction::addRelationshipManagers(Moose::RelationshipManagerType input_rm_type)
 {
-  auto dg_kernel_params = ::validParams<DGKernelBase>();
+  auto dg_kernel_params = DGKernelBase::validParams();
   addRelationshipManagers(input_rm_type, dg_kernel_params);
 }
 

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -16,11 +16,10 @@ registerMooseAction("MoltresApp", PrecursorAction, "add_transfer");
 registerMooseAction("MoltresApp", PrecursorAction, "check_copy_nodal_vars");
 registerMooseAction("MoltresApp", PrecursorAction, "copy_nodal_vars");
 
-template <>
 InputParameters
-validParams<PrecursorAction>()
+PrecursorAction::validParams()
 {
-  InputParameters params = ::validParams<VariableNotAMooseObjectAction>();
+  InputParameters params = VariableNotAMooseObjectAction::validParams();
   params.addRequiredParam<unsigned int>("num_precursor_groups",
                                         "specifies the total number of precursors to create");
   params.addRequiredParam<std::string>("var_name_base", "specifies the base name of the variables");

--- a/src/actions/VariableNotAMooseObjectAction.C
+++ b/src/actions/VariableNotAMooseObjectAction.C
@@ -6,11 +6,10 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/fe_type.h"
 
-template <>
 InputParameters
-validParams<VariableNotAMooseObjectAction>()
+VariableNotAMooseObjectAction::validParams()
 {
-  InputParameters params = validParams<Action>();
+  InputParameters params = Action::validParams();
 
   // Get MooseEnums for the possible order/family options for this variable
   MooseEnum families(AddVariableAction::getNonlinearVariableFamilies());

--- a/src/auxkernels/ConstantDifferenceAux.C
+++ b/src/auxkernels/ConstantDifferenceAux.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", ConstantDifferenceAux);
 
-template <>
 InputParameters
-validParams<ConstantDifferenceAux>()
+ConstantDifferenceAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addParam<Real>("constant", 0.0, "Scalar value subtracted from compareVar");
   params.addRequiredCoupledVar("compareVar", "Coupled variable");
   params.declareControllable("constant");

--- a/src/auxkernels/FissionHeatSourceAux.C
+++ b/src/auxkernels/FissionHeatSourceAux.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", FissionHeatSourceAux);
 
-template <>
 InputParameters
-validParams<FissionHeatSourceAux>()
+FissionHeatSourceAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes", "All the variables that hold the group fluxes. "
                                                "These MUST be listed by decreasing "

--- a/src/auxkernels/FissionHeatSourceTransientAux.C
+++ b/src/auxkernels/FissionHeatSourceTransientAux.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", FissionHeatSourceTransientAux);
 
-template <>
 InputParameters
-validParams<FissionHeatSourceTransientAux>()
+FissionHeatSourceTransientAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes",
                                "All the variables that hold the group fluxes. "

--- a/src/auxkernels/MatDiffusionAux.C
+++ b/src/auxkernels/MatDiffusionAux.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", MatDiffusionAux);
 
-template <>
 InputParameters
-validParams<MatDiffusionAux>()
+MatDiffusionAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredParam<MaterialPropertyName>(
       "prop_name", "the name of the material property we are going to use");
   params.addRequiredCoupledVar("diffuse_var", "The variable that's diffusing.");

--- a/src/auxkernels/ModeratorHeatSourceTransientAux.C
+++ b/src/auxkernels/ModeratorHeatSourceTransientAux.C
@@ -1,6 +1,8 @@
 #include "ModeratorHeatSourceTransientAux.h"
 #include "Function.h"
 
+registerMooseObject("MoltresApp", ModeratorHeatSourceTransientAux);
+
 InputParameters
 ModeratorHeatSourceTransientAux::validParams()
 {

--- a/src/auxkernels/ModeratorHeatSourceTransientAux.C
+++ b/src/auxkernels/ModeratorHeatSourceTransientAux.C
@@ -1,13 +1,10 @@
 #include "ModeratorHeatSourceTransientAux.h"
 #include "Function.h"
 
-registerMooseObject("MoltresApp", ModeratorHeatSourceTransientAux);
-
-template <>
 InputParameters
-validParams<ModeratorHeatSourceTransientAux>()
+ModeratorHeatSourceTransientAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredParam<PostprocessorName>(
       "average_fission_heat",
       "The average fission heat being generated in the fuel portion of the reactor.");

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -5,11 +5,10 @@
 #include "SquirrelApp.h"
 #include "MooseSyntax.h"
 
-template <>
 InputParameters
-validParams<MoltresApp>()
+MoltresApp::validParams()
 {
-  InputParameters params = validParams<MooseApp>();
+  InputParameters params = MooseApp::validParams();
 
   params.set<bool>("use_legacy_uo_initialization") = false;
   params.set<bool>("use_legacy_uo_aux_computation") = false;
@@ -22,7 +21,8 @@ validParams<MoltresApp>()
 // dependent apps know about the MoltresApp label.
 registerKnownLabel("MoltresApp");
 
-MoltresApp::MoltresApp(InputParameters parameters) : MooseApp(parameters)
+MoltresApp::MoltresApp(InputParameters parameters)
+  : MooseApp(parameters)
 {
   MoltresApp::registerAll(_factory, _action_factory, _syntax);
 }

--- a/src/base/MoltresApp.C.module
+++ b/src/base/MoltresApp.C.module
@@ -3,10 +3,10 @@
 #include "AppFactory.h"
 #include "MooseSyntax.h"
 
-template<>
-InputParameters validParams<MoltresApp>()
+InputParameters
+MoltresApp::validParams()
 {
-  InputParameters params = validParams<MooseApp>();
+  InputParameters params = MooseApp::validParams();
 
   params.set<bool>("use_legacy_uo_initialization") = false;
   params.set<bool>("use_legacy_uo_aux_computation") = false;
@@ -15,8 +15,8 @@ InputParameters validParams<MoltresApp>()
   return params;
 }
 
-MoltresApp::MoltresApp(InputParameters parameters) :
-    MooseApp(parameters)
+MoltresApp::MoltresApp(InputParameters parameters)
+  : MooseApp(parameters)
 {
   Moose::registerObjects(_factory);
   MoltresApp::registerObjects(_factory);

--- a/src/base/ScalarTransportBase.C
+++ b/src/base/ScalarTransportBase.C
@@ -2,9 +2,8 @@
 
 #include "libmesh/vector_value.h"
 
-template <>
 InputParameters
-validParams<ScalarTransportBase>()
+ScalarTransportBase::validParams()
 {
   InputParameters params = emptyInputParameters();
   params.addParam<bool>("use_exp_form",

--- a/src/bcs/ConservativeAdvectionNoBCBC.C
+++ b/src/bcs/ConservativeAdvectionNoBCBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", ConservativeAdvectionNoBCBC);
 
-template <>
 InputParameters
-validParams<ConservativeAdvectionNoBCBC>()
+ConservativeAdvectionNoBCBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<RealVectorValue>("velocity", "Velocity vector");
   return params;
 }

--- a/src/bcs/CoupledOutflowBC.C
+++ b/src/bcs/CoupledOutflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", CoupledOutflowBC);
 
-template <>
 InputParameters
-validParams<CoupledOutflowBC>()
+CoupledOutflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredCoupledVar("uvel", "x direction velocity");
   params.addCoupledVar("vvel", 0, "y direction velocity");
   params.addCoupledVar("wvel", 0, "z direction velocity");

--- a/src/bcs/CoupledScalarAdvectionNoBCBC.C
+++ b/src/bcs/CoupledScalarAdvectionNoBCBC.C
@@ -3,12 +3,11 @@
 
 registerMooseObject("MoltresApp", CoupledScalarAdvectionNoBCBC);
 
-template <>
 InputParameters
-validParams<CoupledScalarAdvectionNoBCBC>()
+CoupledScalarAdvectionNoBCBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = IntegratedBC::validParams();
+  params += ScalarTransportBase::validParams();
 
   // Coupled variables
   params.addCoupledVar("u", "x-velocity");

--- a/src/bcs/DiffusionNoBCBC.C
+++ b/src/bcs/DiffusionNoBCBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", DiffusionNoBCBC);
 
-template <>
 InputParameters
-validParams<DiffusionNoBCBC>()
+DiffusionNoBCBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addClassDescription("The Laplacian operator ($-\\nabla \\cdot \\nabla u$), with the weak "
                              "form of $(\\nabla \\phi_i, \\nabla u_h)$.");
   return params;

--- a/src/bcs/INSOutflowBC.C
+++ b/src/bcs/INSOutflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", INSOutflowBC);
 
-template <>
 InputParameters
-validParams<INSOutflowBC>()
+INSOutflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
 
   // Coupled variables
   params.addRequiredCoupledVar("u", "x-velocity");

--- a/src/bcs/INSSymmetryAxisBC.C
+++ b/src/bcs/INSSymmetryAxisBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", INSSymmetryAxisBC);
 
-template <>
 InputParameters
-validParams<INSSymmetryAxisBC>()
+INSSymmetryAxisBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
 
   // Coupled variables
   params.addRequiredCoupledVar("u", "x-velocity");

--- a/src/bcs/LinLogPenaltyDirichletBC.C
+++ b/src/bcs/LinLogPenaltyDirichletBC.C
@@ -3,12 +3,11 @@
 
 registerMooseObject("MoltresApp", LinLogPenaltyDirichletBC);
 
-template <>
 InputParameters
-validParams<LinLogPenaltyDirichletBC>()
+LinLogPenaltyDirichletBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = IntegratedBC::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<Real>("penalty", "LinLogPenalty scalar");
   params.addParam<Real>("value", 0.0, "Boundary value of the variable");
 

--- a/src/bcs/MatDiffusionFluxBC.C
+++ b/src/bcs/MatDiffusionFluxBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", MatDiffusionFluxBC);
 
-template <>
 InputParameters
-validParams<MatDiffusionFluxBC>()
+MatDiffusionFluxBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<MaterialPropertyName>(
       "prop_name", "the name of the material property we are going to use");
 

--- a/src/bcs/PostprocessorCoupledInflowBC.C
+++ b/src/bcs/PostprocessorCoupledInflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", PostprocessorCoupledInflowBC);
 
-template <>
 InputParameters
-validParams<PostprocessorCoupledInflowBC>()
+PostprocessorCoupledInflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredCoupledVar("uvel", "x direction velocity");
   params.addCoupledVar("vvel", 0, "y direction velocity");
   params.addCoupledVar("wvel", 0, "z direction velocity");

--- a/src/bcs/ScalarAdvectionArtDiffNoBCBC.C
+++ b/src/bcs/ScalarAdvectionArtDiffNoBCBC.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", ScalarAdvectionArtDiffNoBCBC);
 
-template <>
 InputParameters
-validParams<ScalarAdvectionArtDiffNoBCBC>()
+ScalarAdvectionArtDiffNoBCBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = IntegratedBC::validParams();
+  params += ScalarTransportBase::validParams();
 
   params.addParam<Real>("scale", 1., "Amount to scale artificial diffusion.");
 

--- a/src/bcs/VacuumConcBC.C
+++ b/src/bcs/VacuumConcBC.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", VacuumConcBC);
 
-template <>
 InputParameters
-validParams<VacuumConcBC>()
+VacuumConcBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = IntegratedBC::validParams();
+  params += ScalarTransportBase::validParams();
   return params;
 }
 

--- a/src/dirackernels/DiracHX.C
+++ b/src/dirackernels/DiracHX.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", DiracHX);
 
-template <>
 InputParameters
-validParams<DiracHX>()
+DiracHX::validParams()
 {
-  InputParameters params = validParams<DiracKernel>();
+  InputParameters params = DiracKernel::validParams();
   params.addRequiredParam<Real>("power", "HX Power in Watts");
   params.addRequiredParam<Point>("point", "The x,y,z coordinates of the point");
   params.declareControllable("power");

--- a/src/kernels/CoupledFissionEigenKernel.C
+++ b/src/kernels/CoupledFissionEigenKernel.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", CoupledFissionEigenKernel);
 
-template <>
 InputParameters
-validParams<CoupledFissionEigenKernel>()
+CoupledFissionEigenKernel::validParams()
 {
-  InputParameters params = validParams<EigenKernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = EigenKernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("group_number", "The current energy group");
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes", "All the variables that hold the group fluxes. "

--- a/src/kernels/CoupledFissionKernel.C
+++ b/src/kernels/CoupledFissionKernel.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", CoupledFissionKernel);
 
-template <>
 InputParameters
-validParams<CoupledFissionKernel>()
+CoupledFissionKernel::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("group_number", "The current energy group");
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("temperature",

--- a/src/kernels/CoupledScalarAdvection.C
+++ b/src/kernels/CoupledScalarAdvection.C
@@ -3,12 +3,11 @@
 
 registerMooseObject("MoltresApp", CoupledScalarAdvection);
 
-template <>
 InputParameters
-validParams<CoupledScalarAdvection>()
+CoupledScalarAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
 
   // Coupled variables
   params.addCoupledVar("u", "x-velocity");

--- a/src/kernels/DecayHeatSource.C
+++ b/src/kernels/DecayHeatSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", DecayHeatSource);
 
-template <>
 InputParameters
-validParams<DecayHeatSource>()
+DecayHeatSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_decay_heat_groups", "The number of decay heat groups.");
   params.addRequiredCoupledVar("heat_concs", "All the variables that hold the decay heat "
                                              "precursor concentrations.");

--- a/src/kernels/DelayedNeutronEigenSource.C
+++ b/src/kernels/DelayedNeutronEigenSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", DelayedNeutronEigenSource);
 
-template <>
 InputParameters
-validParams<DelayedNeutronEigenSource>()
+DelayedNeutronEigenSource::validParams()
 {
-  InputParameters params = validParams<EigenKernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = EigenKernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_precursor_groups", "The number of precursor groups.");
   params.addCoupledVar("temperature", "The temperature used to interpolate material properties");
   params.addRequiredCoupledVar("pre_concs", "All the variables that hold the precursor "

--- a/src/kernels/DelayedNeutronSource.C
+++ b/src/kernels/DelayedNeutronSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", DelayedNeutronSource);
 
-template <>
 InputParameters
-validParams<DelayedNeutronSource>()
+DelayedNeutronSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_precursor_groups", "The number of precursor groups.");
   params.addCoupledVar("temperature", "The temperature used to interpolate material properties");
   params.addRequiredCoupledVar("pre_concs", "All the variables that hold the precursor "

--- a/src/kernels/DivFreeCoupledScalarAdvection.C
+++ b/src/kernels/DivFreeCoupledScalarAdvection.C
@@ -3,12 +3,11 @@
 
 registerMooseObject("MoltresApp", DivFreeCoupledScalarAdvection);
 
-template <>
 InputParameters
-validParams<DivFreeCoupledScalarAdvection>()
+DivFreeCoupledScalarAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
 
   // DivFreeCoupled variables
   params.addCoupledVar("u", "x-velocity");

--- a/src/kernels/FissionHeatSource.C
+++ b/src/kernels/FissionHeatSource.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", FissionHeatSource);
 
-template <>
 InputParameters
-validParams<FissionHeatSource>()
+FissionHeatSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes", "All the variables that hold the group fluxes. "
                                                "These MUST be listed by decreasing "

--- a/src/kernels/GammaHeatSource.C
+++ b/src/kernels/GammaHeatSource.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("MoltresApp", GammaHeatSource);
 
-template <>
 InputParameters
-validParams<GammaHeatSource>()
+GammaHeatSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addRequiredParam<PostprocessorName>(
       "average_fission_heat",
       "The average fission heat being generated in the fuel portion of the reactor.");

--- a/src/kernels/GroupDiffusion.C
+++ b/src/kernels/GroupDiffusion.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", GroupDiffusion);
 
-template <>
 InputParameters
-validParams<GroupDiffusion>()
+GroupDiffusion::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("group_number",
                                         "The group for which this kernel controls diffusion");
   params.addCoupledVar("temperature",

--- a/src/kernels/HeatPrecursorDecay.C
+++ b/src/kernels/HeatPrecursorDecay.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", HeatPrecursorDecay);
 
-template <>
 InputParameters
-validParams<HeatPrecursorDecay>()
+HeatPrecursorDecay::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("decay_heat_group_number",
                                         "The decay heat group this kernel acts on.");
   params.addRequiredParam<std::vector<Real>>("decay_heat_constants", "Decay Heat Constants");

--- a/src/kernels/HeatPrecursorSource.C
+++ b/src/kernels/HeatPrecursorSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", HeatPrecursorSource);
 
-template <>
 InputParameters
-validParams<HeatPrecursorSource>()
+HeatPrecursorSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total number of energy groups");
   params.addRequiredParam<unsigned int>("decay_heat_group_number",
                                         "The decay heat group this kernel acts on.");

--- a/src/kernels/INSBoussinesqBodyForce.C
+++ b/src/kernels/INSBoussinesqBodyForce.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", INSBoussinesqBodyForce);
 
-template <>
 InputParameters
-validParams<INSBoussinesqBodyForce>()
+INSBoussinesqBodyForce::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
 
   params.addClassDescription("Computes a body force for natural convection buoyancy.");
 

--- a/src/kernels/INSMomentumKEpsilon.C
+++ b/src/kernels/INSMomentumKEpsilon.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", INSMomentumKEpsilon);
 
-template <>
 InputParameters
-validParams<INSMomentumKEpsilon>()
+INSMomentumKEpsilon::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
 
   // Coupled variables
   params.addRequiredCoupledVar("u", "x-velocity");

--- a/src/kernels/InScatter.C
+++ b/src/kernels/InScatter.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", InScatter);
 
-template <>
 InputParameters
-validParams<InScatter>()
+InScatter::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("group_number", "The current energy group");
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addCoupledVar("temperature", "The temperature used to interpolate material properties");

--- a/src/kernels/ManuHX.C
+++ b/src/kernels/ManuHX.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", ManuHX);
 
-template <>
 InputParameters
-validParams<ManuHX>()
+ManuHX::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addClassDescription("A uniformly applied heat removal proportional to a difference"
                              "from a nominal temperature. A global heat exchanger.");
   params.addRequiredParam<Real>("htc", "heat transfer coefficient for q'=h*(T-T_ref)");

--- a/src/kernels/NtTimeDerivative.C
+++ b/src/kernels/NtTimeDerivative.C
@@ -6,11 +6,10 @@
 
 registerMooseObject("MoltresApp", NtTimeDerivative);
 
-template <>
 InputParameters
-validParams<NtTimeDerivative>()
+NtTimeDerivative::validParams()
 {
-  InputParameters params = validParams<ScalarTransportTimeDerivative>();
+  InputParameters params = ScalarTransportTimeDerivative::validParams();
   params.addRequiredParam<unsigned int>("group_number",
                                         "The group for which this kernel controls diffusion");
   params.addCoupledVar("temperature",

--- a/src/kernels/PrecursorDecay.C
+++ b/src/kernels/PrecursorDecay.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", PrecursorDecay);
 
-template <>
 InputParameters
-validParams<PrecursorDecay>()
+PrecursorDecay::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("precursor_group_number",
                                         "What precursor group this kernel is acting on.");
   params.addRequiredCoupledVar("temperature",

--- a/src/kernels/PrecursorSource.C
+++ b/src/kernels/PrecursorSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", PrecursorSource);
 
-template <>
 InputParameters
-validParams<PrecursorSource>()
+PrecursorSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes", "All the variables that hold the group fluxes. "
                                                "These MUST be listed by decreasing "

--- a/src/kernels/ScalarAdvectionArtDiff.C
+++ b/src/kernels/ScalarAdvectionArtDiff.C
@@ -3,12 +3,11 @@
 
 registerMooseObject("MoltresApp", ScalarAdvectionArtDiff);
 
-template <>
 InputParameters
-validParams<ScalarAdvectionArtDiff>()
+ScalarAdvectionArtDiff::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addClassDescription("This class computes the residual and Jacobian "
       "contributions from the artificial diffusion term, "
       "$D' = \\tau |u| \\Delta x / 2$.");

--- a/src/kernels/ScalarTransportTimeDerivative.C
+++ b/src/kernels/ScalarTransportTimeDerivative.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", ScalarTransportTimeDerivative);
 
-template <>
 InputParameters
-validParams<ScalarTransportTimeDerivative>()
+ScalarTransportTimeDerivative::validParams()
 {
-  InputParameters params = validParams<TimeKernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = TimeKernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addParam<bool>("lumping", false, "True for mass matrix lumping, false otherwise");
   params.addParam<Real>(
       "conc_scaling", 1, "The amount by which to scale the concentration variable.");

--- a/src/kernels/SelfFissionEigenKernel.C
+++ b/src/kernels/SelfFissionEigenKernel.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", SelfFissionEigenKernel);
 
-template <>
 InputParameters
-validParams<SelfFissionEigenKernel>()
+SelfFissionEigenKernel::validParams()
 {
-  InputParameters params = validParams<EigenKernel>();
+  InputParameters params = EigenKernel::validParams();
   params.addRequiredParam<MaterialPropertyName>("nu_f",
                                                 "The number of neutrons produced per fission.");
   params.addRequiredParam<MaterialPropertyName>("sigma_f",

--- a/src/kernels/SigmaR.C
+++ b/src/kernels/SigmaR.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", SigmaR);
 
-template <>
 InputParameters
-validParams<SigmaR>()
+SigmaR::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("group_number", "The current energy group.");
   params.addCoupledVar("temperature", "The temperature used to interpolate material properties");
   return params;

--- a/src/kernels/TransientFissionHeatSource.C
+++ b/src/kernels/TransientFissionHeatSource.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", TransientFissionHeatSource);
 
-template <>
 InputParameters
-validParams<TransientFissionHeatSource>()
+TransientFissionHeatSource::validParams()
 {
-  InputParameters params = validParams<Kernel>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = Kernel::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredParam<unsigned int>("num_groups", "The total numer of energy groups");
   params.addRequiredCoupledVar("group_fluxes", "All the variables that hold the group fluxes. "
                                                "These MUST be listed by decreasing "

--- a/src/materials/CammiFuel.C
+++ b/src/materials/CammiFuel.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", CammiFuel);
 
-template <>
 InputParameters
-validParams<CammiFuel>()
+CammiFuel::validParams()
 {
-  InputParameters params = validParams<GenericMoltresMaterial>();
+  InputParameters params = GenericMoltresMaterial::validParams();
   return params;
 }
 

--- a/src/materials/CammiModerator.C
+++ b/src/materials/CammiModerator.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", CammiModerator);
 
-template <>
 InputParameters
-validParams<CammiModerator>()
+CammiModerator::validParams()
 {
-  InputParameters params = validParams<GenericMoltresMaterial>();
+  InputParameters params = GenericMoltresMaterial::validParams();
   return params;
 }
 

--- a/src/materials/GenericMoltresMaterial.C
+++ b/src/materials/GenericMoltresMaterial.C
@@ -5,11 +5,10 @@
 
 registerMooseObject("MoltresApp", GenericMoltresMaterial);
 
-template <>
 InputParameters
-validParams<GenericMoltresMaterial>()
+GenericMoltresMaterial::validParams()
 {
-  InputParameters params = validParams<NuclearMaterial>();
+  InputParameters params = NuclearMaterial::validParams();
   params.addRequiredParam<std::string>(
       "property_tables_root",
       "The file root name containing interpolation tables for material properties.");

--- a/src/materials/GraphiteTwoGrpXSFunctionMaterial.C
+++ b/src/materials/GraphiteTwoGrpXSFunctionMaterial.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", GraphiteTwoGrpXSFunctionMaterial);
 
-template <>
 InputParameters
-validParams<GraphiteTwoGrpXSFunctionMaterial>()
+GraphiteTwoGrpXSFunctionMaterial::validParams()
 {
-  InputParameters params = validParams<GenericConstantMaterial>();
+  InputParameters params = GenericConstantMaterial::validParams();
   params.addCoupledVar(
       "temperature", 937, "The temperature field for determining group constants.");
   return params;

--- a/src/materials/MoltresJsonMaterial.C
+++ b/src/materials/MoltresJsonMaterial.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", MoltresJsonMaterial);
 
-template <>
 InputParameters
-validParams<MoltresJsonMaterial>()
+MoltresJsonMaterial::validParams()
 {
-  InputParameters params = validParams<NuclearMaterial>();
+  InputParameters params = NuclearMaterial::validParams();
   params.addRequiredParam<std::string>("base_file", "The file containing macroscopic XS.");
   params.addRequiredParam<std::string>("material_key",
                                        "The file key where the macroscopic XS can be found.");

--- a/src/materials/MsreFuelTwoGrpXSFunctionMaterial.C
+++ b/src/materials/MsreFuelTwoGrpXSFunctionMaterial.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", MsreFuelTwoGrpXSFunctionMaterial);
 
-template <>
 InputParameters
-validParams<MsreFuelTwoGrpXSFunctionMaterial>()
+MsreFuelTwoGrpXSFunctionMaterial::validParams()
 {
-  InputParameters params = validParams<GenericConstantMaterial>();
+  InputParameters params = GenericConstantMaterial::validParams();
   params.addCoupledVar(
       "temperature", 937, "The temperature field for determining group constants.");
   return params;

--- a/src/materials/NuclearMaterial.C
+++ b/src/materials/NuclearMaterial.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("MoltresApp", NuclearMaterial);
 
-template <>
 InputParameters
-validParams<NuclearMaterial>()
+NuclearMaterial::validParams()
 {
-  InputParameters params = validParams<GenericConstantMaterial>();
+  InputParameters params = GenericConstantMaterial::validParams();
   params.addRequiredParam<unsigned>("num_groups",
                                     "The number of groups the energy spectrum is divided into.");
   params.addRequiredParam<unsigned>("num_precursor_groups",

--- a/src/materials/Nusselt.C
+++ b/src/materials/Nusselt.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", Nusselt);
 
-template <>
 InputParameters
-validParams<Nusselt>()
+Nusselt::validParams()
 {
-  InputParameters params = validParams<Material>();
+  InputParameters params = Material::validParams();
   params.addParam<MaterialPropertyName>("k_name", "k", "The name of the thermal conductivity");
   params.addRequiredParam<Real>("L", "The channel radius");
   return params;

--- a/src/materials/RoddedMaterial.C
+++ b/src/materials/RoddedMaterial.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("MoltresApp", RoddedMaterial);
 
-template <>
 InputParameters
-validParams<RoddedMaterial>()
+RoddedMaterial::validParams()
 {
-  InputParameters params = validParams<GenericMoltresMaterial>();
+  InputParameters params = GenericMoltresMaterial::validParams();
   params.addRequiredCoupledVar("rodPosition", "Position of the control rod.");
   params.addRequiredParam<Real>("absorb_factor",
                                 "The material inherits from some other. How much more absorbing?");

--- a/src/postprocessors/AverageFissionHeat.C
+++ b/src/postprocessors/AverageFissionHeat.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", AverageFissionHeat);
 
-template <>
 InputParameters
-validParams<AverageFissionHeat>()
+AverageFissionHeat::validParams()
 {
-  InputParameters params = validParams<ElmIntegTotFissHeatPostprocessor>();
+  InputParameters params = ElmIntegTotFissHeatPostprocessor::validParams();
   return params;
 }
 

--- a/src/postprocessors/DivisionPostprocessor.C
+++ b/src/postprocessors/DivisionPostprocessor.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", DivisionPostprocessor);
 
-template <>
 InputParameters
-validParams<DivisionPostprocessor>()
+DivisionPostprocessor::validParams()
 {
-  InputParameters params = validParams<DifferencePostprocessor>();
+  InputParameters params = DifferencePostprocessor::validParams();
   return params;
 }
 

--- a/src/postprocessors/ElementL2Diff.C
+++ b/src/postprocessors/ElementL2Diff.C
@@ -1,13 +1,11 @@
-
 #include "ElementL2Diff.h"
 
 registerMooseObject("MoltresApp", ElementL2Diff);
 
-template <>
 InputParameters
-validParams<ElementL2Diff>()
+ElementL2Diff::validParams()
 {
-  InputParameters params = validParams<ElementIntegralVariablePostprocessor>();
+  InputParameters params = ElementIntegralVariablePostprocessor::validParams();
   return params;
 }
 

--- a/src/postprocessors/ElmIntegTotFissHeatPostprocessor.C
+++ b/src/postprocessors/ElmIntegTotFissHeatPostprocessor.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", ElmIntegTotFissHeatPostprocessor);
 
-template <>
 InputParameters
-validParams<ElmIntegTotFissHeatPostprocessor>()
+ElmIntegTotFissHeatPostprocessor::validParams()
 {
-  InputParameters params = validParams<ElmIntegTotFissPostprocessor>();
+  InputParameters params = ElmIntegTotFissPostprocessor::validParams();
   return params;
 }
 

--- a/src/postprocessors/ElmIntegTotFissNtsPostprocessor.C
+++ b/src/postprocessors/ElmIntegTotFissNtsPostprocessor.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", ElmIntegTotFissNtsPostprocessor);
 
-template <>
 InputParameters
-validParams<ElmIntegTotFissNtsPostprocessor>()
+ElmIntegTotFissNtsPostprocessor::validParams()
 {
-  InputParameters params = validParams<ElementIntegralPostprocessor>();
+  InputParameters params = ElementIntegralPostprocessor::validParams();
   params.addRequiredCoupledVar(
       "group_fluxes",
       "The group fluxes. MUST be arranged by decreasing energy/increasing group number.");

--- a/src/postprocessors/ElmIntegTotFissPostprocessor.C
+++ b/src/postprocessors/ElmIntegTotFissPostprocessor.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", ElmIntegTotFissPostprocessor);
 
-template <>
 InputParameters
-validParams<ElmIntegTotFissPostprocessor>()
+ElmIntegTotFissPostprocessor::validParams()
 {
-  InputParameters params = validParams<ElementIntegralPostprocessor>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = ElementIntegralPostprocessor::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredCoupledVar(
       "group_fluxes",
       "The group fluxes. MUST be arranged by decreasing energy/increasing group number.");

--- a/src/postprocessors/IntegralNewVariablePostprocessor.C
+++ b/src/postprocessors/IntegralNewVariablePostprocessor.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", IntegralNewVariablePostprocessor);
 
-template <>
 InputParameters
-validParams<IntegralNewVariablePostprocessor>()
+IntegralNewVariablePostprocessor::validParams()
 {
-  InputParameters params = validParams<ElementIntegralPostprocessor>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = ElementIntegralPostprocessor::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }

--- a/src/postprocessors/IntegralOldVariablePostprocessor.C
+++ b/src/postprocessors/IntegralOldVariablePostprocessor.C
@@ -2,12 +2,11 @@
 
 registerMooseObject("MoltresApp", IntegralOldVariablePostprocessor);
 
-template <>
 InputParameters
-validParams<IntegralOldVariablePostprocessor>()
+IntegralOldVariablePostprocessor::validParams()
 {
-  InputParameters params = validParams<ElementIntegralPostprocessor>();
-  params += validParams<ScalarTransportBase>();
+  InputParameters params = ElementIntegralPostprocessor::validParams();
+  params += ScalarTransportBase::validParams();
   params.addRequiredCoupledVar("variable", "The name of the variable that this object operates on");
   return params;
 }

--- a/src/postprocessors/LimitK.C
+++ b/src/postprocessors/LimitK.C
@@ -17,11 +17,10 @@
 
 registerMooseObject("MoltresApp", LimitK);
 
-template <>
 InputParameters
-validParams<LimitK>()
+LimitK::validParams()
 {
-  InputParameters params = validParams<TimestepSize>();
+  InputParameters params = TimestepSize::validParams();
   params.addRequiredParam<Real>("growth_factor",
                                 "How much to grow the time step if multiplication is ok.");
   params.addRequiredParam<Real>("cutback_factor",

--- a/src/postprocessors/SideWeightedIntegralPostprocessor.C
+++ b/src/postprocessors/SideWeightedIntegralPostprocessor.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("MoltresApp", SideWeightedIntegralPostprocessor);
 
-template <>
 InputParameters
-validParams<SideWeightedIntegralPostprocessor>()
+SideWeightedIntegralPostprocessor::validParams()
 {
-  InputParameters params = validParams<SideIntegralVariablePostprocessor>();
+  InputParameters params = SideIntegralVariablePostprocessor::validParams();
   params.addClassDescription("Postprocessor for calculating the weighted integral sum/average of a "
                              "variable along a boundary");
   params.addCoupledVar("weight",


### PR DESCRIPTION
Closes #136, #137 

This PR:
1. replaces all ```#ifndef``` include guards to ```#pragma once``` for QOL improvements (#136),
2. updates all code to use a static function for ```validParams```, replacing the former deprecated method (#137),
3. adds overrides to inherited functions which are redefined in child classes,
4. updates the Squirrel submodule for the latest commits involving similar changes as the above.