### PR TITLE
Deploy a Github Action to auto-update gh-pages branch

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -1,0 +1,35 @@
+# This GitHub Action automatically updates built Doxygen files for Moltres' documentation
+# on `https://arfc.github.io/moltres/` every time a new pull request is merged into devel
+# and subsequently into master after CIVET's continuous integration tests.
+
+name: Doxygen & Github Pages Action
+
+# Activate on pushes and pull requests into master
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      # Generate Doxygen output files in ./docs directory using Doxyfile in base directory
+      - name: Doxygen Action
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          working-directory: .
+      
+      # Merge Doxygen output files in ./docs into gh-pages branch base directory
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -7,9 +7,9 @@ name: Doxygen & Github Pages Action
 # Activate on pushes and pull requests into master
 on:
   push:
-    branches: [ master ]
+    branches: [ devel ]
   pull_request:
-    branches: [ master ]
+    branches: [ devel ]
     
   workflow_dispatch:
 

--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -1,10 +1,9 @@
 # This GitHub Action automatically updates built Doxygen files for Moltres' documentation
-# on `https://arfc.github.io/moltres/` every time a new pull request is merged into devel
-# and subsequently into master after CIVET's continuous integration tests.
+# on `https://arfc.github.io/moltres/` every time a new pull request is merged into devel.
 
 name: Doxygen & Github Pages Action
 
-# Activate on pushes and pull requests into master
+# Activate on pushes and pull requests into devel
 on:
   push:
     branches: [ devel ]


### PR DESCRIPTION
Closes #149 

The `gh-pages` branch currently holds the built Doxygen files for Moltres' documentation on `arfc.github.io/moltres`. This pull request deploys a Github Action workflow which automatically updates the built Doxygen files in the `gh-pages` branch.

This workflow triggers on any push or pull request into the `master` branch. The sequence of events is as follows:
1. A pull request is approved and merged into `devel`
2. `moosetest` pushes latest commits from `devel` to `master` after CIVET's continuous integration testing
3. This push into `master` triggers this workflow
4. The `mattnotmitt/doxygen-action@v1` action builds Doxygen files based on the settings in `$MOLTRES/Doxyfile`. Doxygen creates a `docs/` subdirectory to hold the built files.
5. The `peaceiris/actions-gh-pages@v3` action compares the new built files in `docs/` with the existing built files in `gh-pages`. If there are no changes (i.e. empty commit), it terminates. If there are changes, it pushes the changes to `gh-pages`.

@munkm may have to redeploy Github Pages as described in this [link](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token) after merging this PR if it breaks the existing Github Pages functionality.