### PR TITLE
Disable Doxygen/Github Pages action trigger on pull requests

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -7,8 +7,6 @@ name: Doxygen & Github Pages Action
 on:
   push:
     branches: [ devel ]
-  pull_request:
-    branches: [ devel ]
     
   workflow_dispatch:
 


### PR DESCRIPTION
The current Doxygen/Github Pages action, which updates gh-pages, triggers on both **merges** and **pull request creations** into `devel`. We only need gh-pages to be updated when changes are merged into `devel`, i.e. after PRs are approved.

This PR makes the Doxygen/Github Pages action trigger only when commits are pushed into `devel`, and not when PRs are created.