### PR TITLE
Set up MooseDocs files for documentation

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,0 +1,31 @@
+Content:
+    moltres:
+        root_dir: ${ROOT_DIR}/doc/content
+    moose:
+        root_dir: ${MOOSE_DIR}/framework/doc/content
+        content:
+            - js/*
+            - css/*
+            - contrib/**
+            - media/**
+            - templates/stubs/*
+
+Renderer:
+    type: MooseDocs.base.MaterializeRenderer
+
+Extensions:
+    MooseDocs.extensions.template:
+        active: True
+    MooseDocs.extensions.navigation:
+        name: Moltres
+        repo: https://github.com/arfc/moltres
+        menu:
+            Getting Started: getting_started.md
+            Documentation: source/index.md
+            Help: help.md
+            Citing: citing.md
+    MooseDocs.extensions.appsyntax:
+        executable: ${ROOT_DIR}
+        remove: !include ${MOOSE_DIR}/framework/doc/remove.yml
+        includes:
+            - include

--- a/doc/content/citing.md
+++ b/doc/content/citing.md
@@ -1,0 +1,19 @@
+# Citing Moltres
+
+You may cite Moltres through the following publication:
+
+```tex
+@article{lindsay_introduction_2018,
+    title = {Introduction to {Moltres}: {An} application for simulation of {Molten} {Salt} {Reactors}},
+    volume = {114},
+    issn = {0306-4549},
+    url = {https://linkinghub.elsevier.com/retrieve/pii/S0306454917304760},
+    doi = {10.1016/j.anucene.2017.12.025},
+    journal = {Annals of Nuclear Energy},
+    author = {Lindsay, Alexander and Ridley, Gavin and Rykhlevskii, Andrei and Huff, Kathryn},
+    month = apr,
+    year = {2018},
+    keywords = {Reactor physics, Nuclear fuel cycle, nuclear engineering, agent based modeling, Hydrologic contaminant transport, Object orientation, repository, Systems analysis, Simulation, Multiphysics, Finite elements, MOOSE, Parallel computing},
+    pages = {530--540},
+}
+```

--- a/doc/content/getting_started.md
+++ b/doc/content/getting_started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+TODO: Add getting started instructions

--- a/doc/content/help.md
+++ b/doc/content/help.md
@@ -1,0 +1,3 @@
+# Help
+
+TODO: Add help information

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -1,0 +1,1 @@
+# Moltres

--- a/doc/content/source/index.md
+++ b/doc/content/source/index.md
@@ -1,0 +1,5 @@
+# Source Documentation
+
+The following is a complete list of documented C++ source files in Moltres.
+
+!content list location=source

--- a/doc/moosedocs.py
+++ b/doc/moosedocs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import sys
+import os
+
+# Locate MOOSE directory
+MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__name__), '..', 'moose')))
+if not os.path.exists(MOOSE_DIR):
+    MOOSE_DIR = os.path.abspath(os.path.join(os.path.dirname(__name__), '..', '..', 'moose'))
+if not os.path.exists(MOOSE_DIR):
+    raise Exception('Failed to locate MOOSE, specify the MOOSE_DIR environment variable.')
+os.environ['MOOSE_DIR'] = MOOSE_DIR
+
+# Append MOOSE python directory
+MOOSE_PYTHON_DIR = os.path.join(MOOSE_DIR, 'python')
+if MOOSE_PYTHON_DIR not in sys.path:
+    sys.path.append(MOOSE_PYTHON_DIR)
+
+from MooseDocs import main
+if __name__ == '__main__':
+    sys.exit(main.run())

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -1,0 +1,8 @@
+Applications:
+    moltres:
+        app_types:
+            - MoltresApp
+        content_directory: ${ROOT_DIR}/doc/content
+        remove:
+        log_default: WARNING
+        show_warning: false


### PR DESCRIPTION
Partially fulfills #179 

This pull request adds MooseDocs configuration files which generate a simple static site for Moltres. The site holds documentation for Moltres source files not available in the existing Doxygen documentation in [https://arfc.github.io/moltres](https://arfc.github.io/moltres). To build the site in this current state, users have to run the following commands within the MOOSE Conda environment:
```
cd doc/
./moosedocs.py generate MoltresApp
./moosedocs.py build --serve
```
and navigate to http://127.0.0.1:8000/ on their browser.

The remaining tasks towards building a fully fledged website for Moltres are:
1. Filling up the "Getting Started", "Help", and other pages as required
    - This may involve migrating existing Moltres webpages in arfc.github.io into this website
2. Deploying the website to be accessible online
3. Adding a link to our existing Doxygen-built website, **or** incorporating the Doxygen webpages directly into the website
4. Filling up the documentation "stubs". Running the commands above automatically generates these "stubs" that contain information on the input parameters of each class. We should strive to include more information on the respective physics that each class models and examples of how they're to be used.

I'll add these sub-objectives to #179.