### PR TITLE
Add mesh filter and autolink=False

### DIFF
--- a/python/moltres_xs.py
+++ b/python/moltres_xs.py
@@ -31,7 +31,7 @@ class openmc_xs:
     """
 
     def __init__(self, xs_filename, file_num, xs_summary):
-        sp = openmc.StatePoint(xs_filename)
+        sp = openmc.StatePoint(xs_filename, autolink=False)
         summary = openmc.Summary(xs_summary)
         sp.link_with_summary(summary)
         domain_dict = openmc_ref_modules[file_num].domain_dict
@@ -346,6 +346,8 @@ class openmc_xs:
                 domain_dict[id]["filter"] = openmc.MaterialFilter(domain)
             elif isinstance(domain, openmc.Cell):
                 domain_dict[id]["filter"] = openmc.CellFilter(domain)
+            else:
+                domain_dict[id]["filter"] = openmc.MeshFilter(domain)
             domain_dict[id]["tally"].filters = [
                 domain_dict[id]["filter"],
                 energy_filter,


### PR DESCRIPTION
In this PR, I made 2 changes: 

1) I added `autolink=False`. Previously, without this fix, `moltres_xs.py` will automatically link any `summary.h5` file to the statepoint file. 

2) I added the option of mesh filter for the OpenMC functionality of `moltres_xs.py`