### PR TITLE
Fix readme links to Doxygen and MOOSE resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ reactors.
 
 ## Use
 
-Moltres documentation can be found at
+Moltres documentation can be found
 [here](http://arfc.github.io/software/moltres). Doxygen pages are
 [here](https://arfc.github.io/moltres/classes.html). Outlines of the kernels and boundary
 conditions used to construct the Moltres governing equations can be found on the
@@ -28,8 +28,8 @@ Moltres relies on the MOOSE framework. We suggest that users install the MOOSE
 environment using Conda Packages by following the instructions in the `Install 
 MOOSE Conda Packages` section of
 https://mooseframework.inl.gov/getting_started/installation/conda.html.
-Since the Moltres repository contains MOOSE and Squirrel as Git
-submodules, there is no need to clone MOOSE into a separate directory.
+The Moltres repository contains MOOSE and Squirrel as Git
+submodules, therefore there is no need to clone MOOSE into a separate directory.
 Instead, users can install Moltres by running the following commands in a shell
 after changing into the directory which will hold the Moltres directory (perhaps `~/projects`):
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ reactors.
 ## Use
 
 Moltres documentation can be found at
-http://arfc.github.io/software/moltres. Doxygen pages are
+[here](http://arfc.github.io/software/moltres). Doxygen pages are
 [here](https://arfc.github.io/moltres/classes.html). Outlines of the kernels and boundary
 conditions used to construct the Moltres governing equations can be found on the
 [Moltres wiki](http://arfc.github.io/software/moltres/wiki/). Breakdown of a

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ conditions used to construct the Moltres governing equations can be found on the
 full-fledged Moltres input file can be found
 [here](http://arfc.github.io/software/moltres/wiki/input_example/). New Moltres
 users who have never used MOOSE before are encouraged to check-out the MOOSE
-workshop [slides](https://mooseframework.inl.gov/workshop/index.html#/) and 
-[video](https://www.youtube.com/watch?v=2tJwBsYaLaI) to help understand the
+[website](https://mooseframework.inl.gov/) and
+workshop [slides](https://mooseframework.inl.gov/workshop/index.html#/) for
+tutorials and examples to help understand the
 underlying Moltres components.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ reactors.
 
 Moltres documentation can be found at
 http://arfc.github.io/software/moltres. Doxygen pages are
-[here](https://arfc.github.io/moltres/). Outlines of the kernels and boundary
+[here](https://arfc.github.io/moltres/classes.html). Outlines of the kernels and boundary
 conditions used to construct the Moltres governing equations can be found on the
 [Moltres wiki](http://arfc.github.io/software/moltres/wiki/). Breakdown of a
 full-fledged Moltres input file can be found
 [here](http://arfc.github.io/software/moltres/wiki/input_example/). New Moltres
-users who have never used MOOSE before are encouraged to check-out its
-[wiki](http://mooseframework.org/wiki/),
-[tutorials](http://mooseframework.org/wiki/MooseTutorials/), and
-[examples](http://mooseframework.org/wiki/MooseExamples/) to help understand the
+users who have never used MOOSE before are encouraged to check-out the MOOSE
+workshop [slides](https://mooseframework.inl.gov/workshop/index.html#/) and 
+[video](https://www.youtube.com/watch?v=2tJwBsYaLaI) to help understand the
 underlying Moltres components.
 
 ## Install
 
 Moltres relies on the MOOSE framework. We suggest that users install the MOOSE 
 environment using Conda Packages by following the instructions in the `Install 
-MOOSE Conda Packages` section of https://mooseframework.inl.gov/getting_started/installation/conda.html/.
+MOOSE Conda Packages` section of
+https://mooseframework.inl.gov/getting_started/installation/conda.html/.
 Since the Moltres repository contains MOOSE and Squirrel as Git
 submodules, there is no need to clone MOOSE into a separate directory.
 Instead, users can install Moltres by running the following commands in a shell


### PR DESCRIPTION
This PR addresses two issues highlighted in #187.
1. The old MOOSE wiki, tutorials, and example links are broken. I've replaced them with two new links to the MOOSE workshop slides and video.
2. I changed the Doxygen link to land directly in the Class Index page of the Doxygen documentation site. This is the same approach as the Doxygen link on the MOOSE website. The primary source of documentation is to be the MooseDocs website as described in #179.