### PR TITLE
Change squirrel URL to relative URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "squirrel"]
 	path = squirrel
-	url = ../squirrel
+	url = ../../arfc/squirrel
 [submodule "moose"]
 	path = moose
 	url = ../../idaholab/moose


### PR DESCRIPTION
This PR changes the https-based URL of the `squirrel` submodule to a relative path. This change allows users to default to their preferred authentication method (https or ssh) when downloading/updating the squirrel submodule. The URL of the `MOOSE` already uses the relative path.