### PR TITLE
Removing unused params

### DIFF
--- a/problems/2017_annals_pub_msre_compare/2group_eigen.i
+++ b/problems/2017_annals_pub_msre_compare/2group_eigen.i
@@ -1,11 +1,3 @@
-flow_velocity=21.7 # cm/s. See MSRE-properties.ods
-nt_scale=1e13
-ini_temp=922
-diri_temp=922
-gamma_frac=.075
-R=73
-H=162.56
-
 [GlobalParams]
   num_groups = 2
   num_precursor_groups = 6
@@ -15,7 +7,6 @@ H=162.56
   sss2_input = true
   pre_concs = 'pre1 pre2 pre3 pre4 pre5 pre6'
   account_delayed = false
-  nt_scale = ${nt_scale}
 []
 
 [Mesh]
@@ -59,7 +50,6 @@ H=162.56
 
   bx_norm = 'bnorm'
   k0 = 1.5
-  pfactor = 1e-2
   l_max_its = 100
 
   solve_type = 'PJFNK'

--- a/problems/2017_annals_pub_msre_compare/4group_eigen.i
+++ b/problems/2017_annals_pub_msre_compare/4group_eigen.i
@@ -1,11 +1,3 @@
-flow_velocity=21.7 # cm/s. See MSRE-properties.ods
-nt_scale=1e13
-ini_temp=922
-diri_temp=922
-gamma_frac=.075
-R=73
-H=162.56
-
 [GlobalParams]
   num_groups = 4
   num_precursor_groups = 6
@@ -15,7 +7,6 @@ H=162.56
   sss2_input = true
   pre_concs = 'pre1 pre2 pre3 pre4 pre5 pre6'
   account_delayed = false
-  nt_scale = ${nt_scale}
 []
 
 [Mesh]
@@ -57,7 +48,6 @@ H=162.56
 
   bx_norm = 'bnorm'
   k0 = 1.5
-  pfactor = 1e-2
   l_max_its = 100
 
   solve_type = 'PJFNK'

--- a/tests/decay_heat/decay_heat.i
+++ b/tests/decay_heat/decay_heat.i
@@ -4,14 +4,12 @@ global_temperature=922
 [GlobalParams]
   num_groups = 2
   num_precursor_groups = 6
-  num_decay_heat_groups = 3
   group_fluxes = '1e9 1e9'
   use_exp_form = false
   decay_heat_fractions = '.01 .01 .01'
   decay_heat_constants = '1 .1 .01'
   temperature = ${global_temperature}
   sss2_input = false
-  transient = false
 [../]
 
 [Mesh]

--- a/tests/diracHX/sub.i
+++ b/tests/diracHX/sub.i
@@ -7,11 +7,9 @@ flow_velocity=0.5 # cm/s. See MSRE-properties.ods
 [GlobalParams]
   num_groups = 0
   num_precursor_groups = 6
-  use_exp_form = false
   group_fluxes = ''
   temperature = temp
   sss2_input = false
-  pre_concs = 'pre1 pre2 pre3 pre4 pre5 pre6'
   # account_delayed = true
 []
 

--- a/tests/laminar_flow/boussinesq_square.i
+++ b/tests/laminar_flow/boussinesq_square.i
@@ -183,14 +183,12 @@ ymax=.05
   [./buoyancy_x]
     type = INSBoussinesqBodyForce
     variable = ux
-    dT = deltaT
     component = 0
     temperature = temp
   [../]
   [./buoyancy_y]
     type = INSBoussinesqBodyForce
     variable = uy
-    dT = deltaT
     component = 1
     temperature = temp
   [../]

--- a/tests/nts/nts.i
+++ b/tests/nts/nts.i
@@ -45,7 +45,6 @@
 
   bx_norm = 'bnorm'
   k0 = 1.5
-  pfactor = 1e-2
   l_max_its = 100
 
   # solve_type = 'PJFNK'

--- a/tests/nts/nts_no_action.i
+++ b/tests/nts/nts_no_action.i
@@ -102,7 +102,6 @@
 
   bx_norm = 'bnorm'
   k0 = 1.5
-  pfactor = 1e-2
   l_max_its = 100
 
   # solve_type = 'PJFNK'

--- a/tests/postprocessors/side_weighted_integral.i
+++ b/tests/postprocessors/side_weighted_integral.i
@@ -76,7 +76,6 @@
     variable = u
     boundary = 'top'
     weight = v
-    output = 'exodus console'
   [../]
 
   # Test integral of parabola v across top boundary, weighted by u=1
@@ -86,7 +85,6 @@
     variable = v
     boundary = 'top'
     weight = u
-    output = 'exodus console'
   [../]
 
   # Test integral of parabola v across top boundary, weighted by parabola v
@@ -96,7 +94,6 @@
     variable = v
     boundary = 'top'
     weight = v
-    output = 'exodus console'
   [../]
 []
 

--- a/tests/postprocessors/side_weighted_integral_RZ.i
+++ b/tests/postprocessors/side_weighted_integral_RZ.i
@@ -80,7 +80,6 @@
     variable = u
     boundary = 'top'
     weight = v
-    output = 'exodus console'
   [../]
 
   # Test integral of parabola v across top boundary, weighted by u=1
@@ -90,7 +89,6 @@
     variable = v
     boundary = 'top'
     weight = u
-    output = 'exodus console'
   [../]
 
   # Test integral of parabola v across top boundary, weighted by parabola v
@@ -100,7 +98,6 @@
     variable = v
     boundary = 'top'
     weight = v
-    output = 'exodus console'
   [../]
 []
 


### PR DESCRIPTION
MOOSE is changing the default behavior of unused parameters from a warning to an error. Since there are tests in this Moose app with unused parameters, this app's tests must have there unused parameters removed.

Closes #206 