### PR TITLE
Update GH action for docs to use latest Conda moose env

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           conda deactivate
           conda activate moose-env
-          mamba install moose-tools=2021.07.14 moose-libmesh=2021.07.14
+          mamba install moose-tools moose-libmesh
           conda deactivate
           conda activate moose-env
           git submodule init && git submodule update


### PR DESCRIPTION
When I updated the moose submodule and the docs in #208, I forgot to update the Conda moose environment that the github action uses to build the docs website. It seems that the MOOSE team also removed old Conda moose environments from circulation. This led to the GH action failing as shown [here](https://github.com/arfc/moltres/actions/runs/2678976353).

With this PR, the docs GH action will install and use the latest Conda moose environment.