### PR TITLE
Build doc without MOOSE optional modules

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
           conda deactivate
           conda activate moose-env
           git submodule init && git submodule update
-          make -j 2
+        make NAVIER_STOKES:='no' PHASE_FIELD:='no' -j 2
           cd doc
           ./moosedocs.py build --destination html
       

--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
           conda deactivate
           conda activate moose-env
           git submodule init && git submodule update
-        make NAVIER_STOKES:='no' PHASE_FIELD:='no' -j 2
+          make NAVIER_STOKES:='no' PHASE_FIELD:='no' -j 2
           cd doc
           ./moosedocs.py build --destination html
       

--- a/doc/content/development/contributing.md
+++ b/doc/content/development/contributing.md
@@ -98,11 +98,17 @@ for an in-depth guide on Git workflows.
 If you make any changes to the source code which alters functionality, please make
 the corresponding changes to the documentation in `moltres/doc/content/source` for the specific
 class you modified. You may build this website locally to review your documentation
-changes by running the following commands in the `moltres/doc` directory:
+changes by compiling Moltres without the optional MOOSE modules and running the MooseDocs python
+script as follows:
 
 ```bash
+make NAVIER_STOKES:='no' PHASE_FIELD:='no' -j 4
+cd doc
 ./moosedocs.py build --serve
 ```
+
+Remember to recompile Moltres using `make -j 4` afterwards if you intend to run Moltres input
+files.
 
 !alert tip
 Feel free to reach out to anyone in the Moltres development team for help with documentation.

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -2,20 +2,18 @@
 
 ## 1. Install the Conda MOOSE Environment
 
-Moltres relies on the MOOSE framework. We suggest that users install the MOOSE environment using
-Conda packages by following the instructions in the "Install Mambaforge3" and "Install MOOSE Conda
-Packages" section of the MOOSE
-[installation guide](https://mooseframework.inl.gov/getting_started/installation/conda.html). The
-`moose-tools` and `moose-libmesh` Conda package versions which are compatible with the current
-MOOSE Git submodule on this repository are `moose-tools=2022.04.18` and `moose-libmesh=2022.06.06`.
+Moltres relies on the MOOSE framework. We suggest that users install the latest MOOSE environment
+using Conda packages by following the instructions in the "Install Mambaforge3" and "Install MOOSE
+Conda Packages" section of the MOOSE
+[installation guide](https://mooseframework.inl.gov/getting_started/installation/conda.html).
 We cannot guarantee compatibility with the older MOOSE builds and their corresponding Conda
 environments. The latest MOOSE Conda environment is usually compatible unless the MOOSE team
 introduces significant changes to the dependencies. We encourage you to post a GitHub issue if you
 encounter compatibility issues so that we can rectify it as soon as possible. Run the following
-command to install the specified package versions:
+command to install the latest package versions:
 
 ```bash
-mamba install moose-tools=2022.04.18 moose-libmesh=2022.06.06
+mamba install moose-tools moose-libmesh
 ```
 
 ## 2. Clone Moltres


### PR DESCRIPTION
Building docs with MOOSE optional modules compiled with Moltres throws out errors because MooseDocs can't find the markdown doc files for the optional modules (https://github.com/arfc/moltres/actions/runs/2693313189). This is seemingly related to idaholab/moose#12158. For some reason, this error surfaced only recently and it doesn't occur if the user had built Moltres without the optional modules in a previous compilation.

I updated the GH documentation action to compile Moltres without the optional modules for MooseDocs to avoid the errors. This does not affect our documentation because we have never hosted documentation for the optional modules. I also updated the user instructions for building docs.

On a side note, I also updated the conda env instructions for Moltres installation to encourage users to use the latest conda moose environment.