### PR TITLE
Load squirrel docs and change parameters syntax text color

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -3,6 +3,8 @@ Content:
         root_dir: ${ROOT_DIR}/doc/content
     moose:
         root_dir: ${MOOSE_DIR}/framework/doc/content
+    squirrel:
+        root_dir: ${ROOT_DIR}/squirrel/doc/content
 
 Renderer:
     type: MooseDocs.base.MaterializeRenderer

--- a/doc/content/css/moltres.css
+++ b/doc/content/css/moltres.css
@@ -37,7 +37,7 @@ blockquote {
 }
 
 .moose-parameter-name{
-    color:var(--uiuc-blue);
+    color:var(--uiuc-second-blue);
 }
 
 nav,

--- a/doc/content/syntax/index.md
+++ b/doc/content/syntax/index.md
@@ -1,3 +1,3 @@
 # Complete Syntax
 
-!syntax complete groups=MoltresApp
+!syntax complete groups=MoltresApp SquirrelApp


### PR DESCRIPTION
With arfc/squirrel#10, documentation stubs are now available for Squirrel objects.

This PR adds links to the squirrel docs on the Moltres Syntax webpage. This PR also changes the text color of parameters on the syntax webpages to improve visibility in dark mode.

Before text color change:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/30237775/205741600-ff91a16b-7c8e-4668-aa58-a4550910e9c2.png">

After text color change:
<img width="653" alt="image" src="https://user-images.githubusercontent.com/30237775/205741663-a741f284-8be3-4d29-a8b2-132a21780c15.png">
