### PR TITLE
Fix deprecated inputs/code for coord_type, variableType, multiapp

### DIFF
--- a/problems/2017_annals_pub_msre_compare/2group.i
+++ b/problems/2017_annals_pub_msre_compare/2group.i
@@ -19,11 +19,8 @@ H=162.56
 []
 
 [Mesh]
-  file = '2d_lattice_structured.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured.msh'
 []
 
 [Variables]

--- a/problems/2017_annals_pub_msre_compare/2group_eigen.i
+++ b/problems/2017_annals_pub_msre_compare/2group_eigen.i
@@ -10,13 +10,9 @@
 []
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured.msh'
 []
-
-[Problem]
-  coord_type = RZ
-[]
-
 
 [Nt]
   var_name_base = group

--- a/problems/2017_annals_pub_msre_compare/4group.i
+++ b/problems/2017_annals_pub_msre_compare/4group.i
@@ -19,11 +19,8 @@ H=162.56
 []
 
 [Mesh]
-  file = '2d_lattice_structured.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured.msh'
 []
 
 [Variables]

--- a/problems/2017_annals_pub_msre_compare/4group_eigen.i
+++ b/problems/2017_annals_pub_msre_compare/4group_eigen.i
@@ -10,13 +10,9 @@
 []
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured.msh'
 []
-
-[Problem]
-  coord_type = RZ
-[]
-
 
 [Nt]
   var_name_base = group

--- a/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
+++ b/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
@@ -19,11 +19,8 @@ H=162.56
 []
 
 [Mesh]
-  file = '2d_lattice_structured.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured.msh'
 []
 
 [Variables]

--- a/src/actions/PrecursorAction.C
+++ b/src/actions/PrecursorAction.C
@@ -459,12 +459,11 @@ PrecursorAction::addMultiAppTransfer(const std::string & var_name)
   {
     std::string transfer_name = "toloop_Transfer_" + var_name + "_" + _object_suffix;
     InputParameters params = _factory.getValidParams("MultiAppPostprocessorTransfer");
-    params.set<MultiAppName>("multi_app") = getParam<MultiAppName>("multi_app");
+    params.set<MultiAppName>("to_multi_app") = getParam<MultiAppName>("multi_app");
     params.set<PostprocessorName>("from_postprocessor") =
         "Outlet_Average_" + var_name + "_" + _object_suffix;
     params.set<PostprocessorName>("to_postprocessor") =
         "Inlet_Average_" + var_name + "_" + _object_suffix;
-    params.set<MultiMooseEnum>("direction") = "to_multiapp";
 
     _problem->addTransfer("MultiAppPostprocessorTransfer", transfer_name, params);
   }
@@ -473,12 +472,11 @@ PrecursorAction::addMultiAppTransfer(const std::string & var_name)
   {
     std::string transfer_name = "fromloop_Transfer_" + var_name + "_" + _object_suffix;
     InputParameters params = _factory.getValidParams("MultiAppPostprocessorTransfer");
-    params.set<MultiAppName>("multi_app") = getParam<MultiAppName>("multi_app");
+    params.set<MultiAppName>("from_multi_app") = getParam<MultiAppName>("multi_app");
     params.set<PostprocessorName>("from_postprocessor") =
         "Outlet_Average_" + var_name + "_" + _object_suffix;
     params.set<PostprocessorName>("to_postprocessor") =
         "Inlet_Average_" + var_name + "_" + _object_suffix;
-    params.set<MultiMooseEnum>("direction") = "from_multiapp";
     params.set<MooseEnum>("reduction_type") = "average";
 
     _problem->addTransfer("MultiAppPostprocessorTransfer", transfer_name, params);

--- a/src/actions/VariableNotAMooseObjectAction.C
+++ b/src/actions/VariableNotAMooseObjectAction.C
@@ -52,7 +52,7 @@ VariableNotAMooseObjectAction::addVariable(const std::string & var_name)
 {
   std::set<SubdomainID> blocks = getSubdomainIDs();
   auto fe_type = AddVariableAction::feType(_pars);
-  auto type = AddVariableAction::determineType(fe_type, 1);
+  auto type = AddVariableAction::variableType(fe_type);
   auto var_params = _factory.getValidParams(type);
   var_params.applySpecificParameters(_pars, {"family", "order"});
   var_params.set<std::vector<Real>>("scaling") = {getParam<Real>("scaling")};

--- a/tests/decay_heat/decay_heat.i
+++ b/tests/decay_heat/decay_heat.i
@@ -13,11 +13,11 @@ global_temperature=922
 [../]
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured_smaller.msh'
 [../]
 
 [Problem]
-  coord_type = RZ
   kernel_coverage_check = false
 []
 

--- a/tests/nts/nts.i
+++ b/tests/nts/nts.i
@@ -9,11 +9,8 @@
 []
 
 [Mesh]
-  file = '2d_lattice_structured_smaller.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured_smaller.msh'
 []
 
 [Nt]

--- a/tests/nts/nts_no_action.i
+++ b/tests/nts/nts_no_action.i
@@ -9,11 +9,8 @@
 []
 
 [Mesh]
-  file = '2d_lattice_structured_smaller.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured_smaller.msh'
 []
 
 [Variables]

--- a/tests/postprocessors/side_weighted_integral_RZ.i
+++ b/tests/postprocessors/side_weighted_integral_RZ.i
@@ -1,4 +1,5 @@
 [Mesh]
+  coord_type = RZ
   [./box]
     type = GeneratedMeshGenerator
     dim = 2
@@ -9,10 +10,6 @@
     ymin = 0
     ymax = 1
   [../]
-[]
-
-[Problem]
-  coord_type = RZ
 []
 
 [Variables]

--- a/tests/pre/pre.i
+++ b/tests/pre/pre.i
@@ -11,11 +11,11 @@ global_temperature=922
 [../]
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured_smaller.msh'
 [../]
 
 [Problem]
-  coord_type = RZ
   kernel_coverage_check = false
 []
 

--- a/tests/pre/pre_loop.i
+++ b/tests/pre/pre_loop.i
@@ -11,11 +11,11 @@ global_temperature=922
 [../]
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured_smaller.msh'
 [../]
 
 [Problem]
-  coord_type = RZ
   kernel_coverage_check = false
 []
 
@@ -57,9 +57,9 @@ global_temperature=922
   line_search = 'none'
   nl_max_its = 30
   l_max_its = 100
-  picard_max_its = 5
-  picard_rel_tol = 1e-6
-  picard_abs_tol = 1e-5
+  fixed_point_max_its = 5
+  fixed_point_rel_tol = 1e-6
+  fixed_point_abs_tol = 1e-5
   dtmin = 1e-2
   [./TimeStepper]
     type = IterationAdaptiveDT

--- a/tests/pre/pre_loop_ins.i
+++ b/tests/pre/pre_loop_ins.i
@@ -15,6 +15,7 @@ ymax=100
 []
 
 [Mesh]
+  coord_type = RZ
   [./box]
     type = GeneratedMeshGenerator
     dim = 2
@@ -34,7 +35,6 @@ ymax=100
 []
 
 [Problem]
-  coord_type = RZ
   kernel_coverage_check = false
 []
 
@@ -91,14 +91,14 @@ ymax=100
     variable = p
     u = ux
     v = uy
-    p = p
+    pressure = p
   [../]
   [./ux_momentum]
     type = INSMomentumLaplaceFormRZ
     variable = ux
     u = ux
     v = uy
-    p = p
+    pressure = p
     component = 0
   [../]
   [./uy_momentum]
@@ -106,7 +106,7 @@ ymax=100
     variable = uy
     u = ux
     v = uy
-    p = p
+    pressure = p
     component = 1
   [../]
 []
@@ -190,9 +190,9 @@ ymax=100
   line_search = 'none'
   nl_max_its = 30
   l_max_its = 100
-  picard_max_its = 5
-  picard_rel_tol = 1e-6
-  picard_abs_tol = 1e-5
+  fixed_point_max_its = 5
+  fixed_point_rel_tol = 1e-6
+  fixed_point_abs_tol = 1e-5
   dtmin = 1e-2
   [./TimeStepper]
     type = IterationAdaptiveDT

--- a/tests/temp/temp.i
+++ b/tests/temp/temp.i
@@ -10,11 +10,8 @@ ini_temp=922
 []
 
 [Mesh]
-  file = '2d_lattice_structured_smaller.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured_smaller.msh'
 []
 
 [Variables]

--- a/tests/twod_axi_coupled/auto_diff_rho.i
+++ b/tests/twod_axi_coupled/auto_diff_rho.i
@@ -34,12 +34,9 @@ nt_scale=1e13
 []
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured.msh'
 [../]
-
-[Problem]
-  coord_type = RZ
-[]
 
 [Precursors]
   [./pres]

--- a/tests/twod_axi_coupled/auto_diff_rho_serpent.i
+++ b/tests/twod_axi_coupled/auto_diff_rho_serpent.i
@@ -34,12 +34,9 @@ nt_scale=1e13
 []
 
 [Mesh]
+  coord_type = RZ
   file = '2d_lattice_structured.msh'
 [../]
-
-[Problem]
-  coord_type = RZ
-[]
 
 [Precursors]
   [./pres]


### PR DESCRIPTION
This PR fixes some deprecation errors mentioned in #197 involving the following:

- p -> pressure (input parameter)
- coord_type -> Mesh/coord_type
- AddVariableAction::determinetype() -> AddVariableAction::variableType()
- multiapp -> from_multiapp/to_multiapp (input parameter)
- picard -> fixed_point (input parameter)

in the test input files.