### PR TITLE
Use mambaforge for gh pages workflow

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
       # ./doc/html
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge,https://conda.software.inl.gov/public
           activate-environment: moose-env
       - shell: bash -l {0}


### PR DESCRIPTION
After PR #225 was merged, the github workflow for automated documentation updates failed due to an issue with the miniconda setup component (https://github.com/conda-incubator/setup-miniconda/issues/274).

Link to failed workflow run: https://github.com/arfc/moltres/actions/runs/4138494678/jobs/7154966419

It failed due to unresolvable conda package compatibility conflicts, which I fixed by replacing miniforge with mambaforge.

Link to successful workflow run on my fork after the fix: https://github.com/smpark7/moltres/actions/runs/4147898479/jobs/7175306608