### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/actions/VariableNotAMooseObjectAction.C
+++ b/src/actions/VariableNotAMooseObjectAction.C
@@ -38,12 +38,12 @@ VariableNotAMooseObjectAction::getSubdomainIDs()
 {
   // Extract and return the block ids supplied in the input
   std::set<SubdomainID> blocks;
-  std::vector<SubdomainName> block_param = getParam<std::vector<SubdomainName>>("block");
-  for (const auto & subdomain_name : block_param)
-  {
-    SubdomainID blk_id = _problem->mesh().getSubdomainID(subdomain_name);
-    blocks.insert(blk_id);
-  }
+  if (isParamValid("block"))
+    for (const auto & subdomain_name : getParam<std::vector<SubdomainName>>("block"))
+    {
+      SubdomainID blk_id = _problem->mesh().getSubdomainID(subdomain_name);
+      blocks.insert(blk_id);
+    }
   return blocks;
 }
 

--- a/src/kernels/TransientFissionHeatSource.C
+++ b/src/kernels/TransientFissionHeatSource.C
@@ -15,8 +15,8 @@ TransientFissionHeatSource::validParams()
   params.addParam<unsigned int>("num_decay_heat_groups", 0, "The number of decay heat groups.");
   params.addCoupledVar("heat_concs", "All the variables that hold the decay heat "
                                      "precursor concentrations.");
-  params.addParam<std::vector<Real>>("decay_heat_fractions", "Decay Heat Fractions");
-  params.addParam<std::vector<Real>>("decay_heat_constants", "Decay Heat Constants");
+  params.addParam<std::vector<Real>>("decay_heat_fractions", {}, "Decay Heat Fractions");
+  params.addParam<std::vector<Real>>("decay_heat_constants", {}, "Decay Heat Constants");
   params.addParam<bool>("account_decay_heat", false, "Whether to account for decay heat.");
   return params;
 }


### PR DESCRIPTION
## Bug Description
<!--A clear and concise description of the error, failure, fault, incorrect or unexpected result, or unintended behavior (Note: A missing feature is not a bug.).-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This new fix in MOOSE cause several tests failed in Moltres which don't provide default value for vector parameter. 

## Impact
<!--Does this prevent you from getting your work done, or is it more of an annoyance?-->
This patch is made to fix the failed Moltres tests due to the new changes in MOOSE