### PR TITLE
Replace conda packages of moose dependencies

### DIFF
--- a/.github/workflows/auto-update-gh-pages.yml
+++ b/.github/workflows/auto-update-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           conda deactivate
           conda activate moose-env
-          mamba install moose-tools moose-libmesh
+          mamba install moose-dev
           conda deactivate
           conda activate moose-env
           git submodule init && git submodule update

--- a/doc/content/getting_started/installation.md
+++ b/doc/content/getting_started/installation.md
@@ -3,18 +3,13 @@
 ## 1. Install the Conda MOOSE Environment
 
 Moltres relies on the MOOSE framework. We suggest that users install the latest MOOSE environment
-using Conda packages by following the instructions in the "Install Mambaforge3" and "Install MOOSE
-Conda Packages" section of the MOOSE
+using Conda packages by following the instructions in the "Conda MOOSE Environment" and "Install
+MOOSE" sections of the MOOSE
 [installation guide](https://mooseframework.inl.gov/getting_started/installation/conda.html).
-We cannot guarantee compatibility with the older MOOSE builds and their corresponding Conda
+We cannot guarantee compatibility with older MOOSE builds and their corresponding Conda
 environments. The latest MOOSE Conda environment is usually compatible unless the MOOSE team
 introduces significant changes to the dependencies. We encourage you to post a GitHub issue if you
-encounter compatibility issues so that we can rectify it as soon as possible. Run the following
-command to install the latest package versions:
-
-```bash
-mamba install moose-tools moose-libmesh
-```
+encounter compatibility issues so that we can rectify it as soon as possible.
 
 ## 2. Clone Moltres
 


### PR DESCRIPTION
Replaces instructions for installing `moose-tools` and `moose-libmesh` conda packages with `moose-dev` as is the latest practice for MOOSE apps.

This PR also fixes the [failing gh-pages deployment](https://github.com/arfc/moltres/actions/runs/7390876488/job/20106659549) as a result of the missing wasp dependency (`moose-dev` contains wasp).