### PR TITLE
Fix coord_type deprecated input

### DIFF
--- a/tests/nts/nts_no_action.i
+++ b/tests/nts/nts_no_action.i
@@ -14,11 +14,8 @@
 []
 
 [Mesh]
-  file = '2d_lattice_structured_smaller.msh'
-[]
-
-[Problem]
   coord_type = RZ
+  file = '2d_lattice_structured_smaller.msh'
 []
 
 [Variables]


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->

The `coord_type` input parameter should be in the `Mesh` block. The current placement in the `Problem` block is deprecated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] CI tests pass
  - [x] Local tests pass (including Serpent2 integration tests)

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #
Deprecation CI: https://civet.inl.gov/job/2853431/

## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
