### PR TITLE
Remove deprecated reviewer configuration option in dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request review from @smpark7 for MOOSE auto-updates
+/moose/ @smpark7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,3 @@ updates:
     labels:
       - "Comp:Core"
       - "Priority:1-Critical" 
-    reviewers:
-      - "smpark7"
-      - "nglaser3"


### PR DESCRIPTION
## Summary of changes
GitHub is removing the "reviewers" configuration option in Dependabot due to conflicts with the CODEOWNERS functionality. This PR migrates the repo to using code owners. https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] CI tests pass
  - [ ] Local tests pass (including Serpent2 integration tests)

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
