### PR TITLE
Fix copy-construct deprecation

### DIFF
--- a/include/base/MoltresApp.h
+++ b/include/base/MoltresApp.h
@@ -5,7 +5,7 @@
 class MoltresApp : public MooseApp
 {
 public:
-  MoltresApp(InputParameters parameters);
+  MoltresApp(const InputParameters & parameters);
 
   static InputParameters validParams();
 

--- a/src/base/MoltresApp.C
+++ b/src/base/MoltresApp.C
@@ -16,7 +16,7 @@ MoltresApp::validParams()
 // dependent apps know about the MoltresApp label.
 registerKnownLabel("MoltresApp");
 
-MoltresApp::MoltresApp(InputParameters parameters)
+MoltresApp::MoltresApp(const InputParameters & parameters)
   : MooseApp(parameters)
 {
   MoltresApp::registerAll(_factory, _action_factory, _syntax);


### PR DESCRIPTION
## Summary of changes
Copy constructing input parameters in MoltresApp is deprecated. [Failing deprecation test](https://civet.inl.gov/job/3147617/)
This is a simple change as directed by the deprecation error message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] CI tests pass
  - [ ] Local tests pass (including Serpent2 integration tests)

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
