### PR TITLE
Change deprecated velocity parameter

### DIFF
--- a/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
+++ b/problems/033117_nts_temp_pre_parsed_mat/3d_auto_diff_rho.i
@@ -157,7 +157,7 @@ offset = 2.5
   []
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
-    velocity = '0 0 ${flow_velocity}'
+    velocity_variable = '0 0 ${flow_velocity}'
     variable = temp
     block = 'fuel'
   []

--- a/problems/2017_annals_pub_msre_compare/2group.i
+++ b/problems/2017_annals_pub_msre_compare/2group.i
@@ -86,7 +86,7 @@ H = 162.56
   []
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
-    velocity = '0 ${flow_velocity} 0'
+    velocity_variable = '0 ${flow_velocity} 0'
     variable = temp
     block = 'fuel'
   []

--- a/problems/2017_annals_pub_msre_compare/4group.i
+++ b/problems/2017_annals_pub_msre_compare/4group.i
@@ -86,7 +86,7 @@ H = 162.56
   []
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
-    velocity = '0 ${flow_velocity} 0'
+    velocity_variable = '0 ${flow_velocity} 0'
     variable = temp
     block = 'fuel'
   []

--- a/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
+++ b/problems/2017_annals_pub_msre_compare/auto_diff_rho.i
@@ -86,7 +86,7 @@ H = 162.56
   []
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
-    velocity = '0 ${flow_velocity} 0'
+    velocity_variable = '0 ${flow_velocity} 0'
     variable = temp
     block = 'fuel'
   []

--- a/tests/temp/temp.i
+++ b/tests/temp/temp.i
@@ -35,7 +35,7 @@ ini_temp = 922
   []
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
-    velocity = '0 ${flow_velocity} 0'
+    velocity_variable = '0 ${flow_velocity} 0'
     variable = temp
     block = 'fuel'
   []

--- a/tutorial/transient/transient.i
+++ b/tutorial/transient/transient.i
@@ -127,7 +127,7 @@
   [temp_advection_fuel]
     type = ConservativeTemperatureAdvection
     variable = temp
-    velocity = '0 18.085 0'
+    velocity_variable = '0 18.085 0'
     block = '0'
   []
   [temp_diffusion]


### PR DESCRIPTION
## Summary of changes
The `velocity` input parameter for `ConservativeAdvection` has been replaced with `velocity_variable`. The new parameter remains functionally identical. [Current deprecation test results](https://civet.inl.gov/job/3151581/)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] CI tests pass
  - [ ] Local tests pass (including Serpent2 integration tests)

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
